### PR TITLE
[컴포넌트] 태그 선택 컴포넌트 리팩토링

### DIFF
--- a/src/app/testpage/tag-selector/page.tsx
+++ b/src/app/testpage/tag-selector/page.tsx
@@ -41,14 +41,31 @@ export default function TagSelectorTestPage() {
   };
   return (
     <div className="flex h-full w-full flex-col gap-10 bg-[#242429] p-10">
-      <div className="w-100">
-        <TagSelector tags={SESSION_TAGS} onChange={handleSessionChange} />
-      </div>
       <div className="w-70">
-        <TagSelector tags={GENRE_TAGS} onChange={handleGenreChange} />
+        <TagSelector
+          mode="selectable"
+          tags={GENRE_TAGS}
+          onChange={handleGenreChange}
+        />
       </div>
       <div className="w-130">
-        <TagSelector tags={FEEDBACK_TAGS} />
+        <TagSelector mode="selectable" tags={FEEDBACK_TAGS} />
+      </div>
+      <div className="w-100">
+        <h1 className="mb-5 text-white">Selectable</h1>
+        <TagSelector
+          mode="selectable"
+          tags={SESSION_TAGS}
+          onChange={handleSessionChange}
+        />
+      </div>
+      <div className="w-100">
+        <h1 className="mb-5 text-white">ReadOnly</h1>
+        <TagSelector
+          mode="readonly"
+          tags={SESSION_TAGS}
+          readonlySelected={['보컬', '드럼']}
+        />
       </div>
     </div>
   );

--- a/src/components/commons/TagSelector.tsx
+++ b/src/components/commons/TagSelector.tsx
@@ -6,15 +6,28 @@ import { clsx } from 'clsx';
 
 interface TagSelectorProps {
   tags: string[];
+  mode: 'selectable' | 'readonly';
+  readonlySelected?: string[];
   onChange?: (selected: string[]) => void;
 }
 
-export default function TagSelector({ tags, onChange }: TagSelectorProps) {
+export default function TagSelector({
+  tags,
+  mode,
+  readonlySelected,
+  onChange,
+}: TagSelectorProps) {
   const [selected, setSelected] = useState<string[]>([]);
-  const selectedSet = useMemo(() => new Set(selected), [selected]);
+  const selectedSet = useMemo(
+    () => new Set(mode === 'readonly' ? readonlySelected || [] : selected),
+    [mode, readonlySelected, selected],
+  );
 
   const toggleTag = useCallback(
     (tag: string) => {
+      if (mode === 'readonly') {
+        return;
+      }
       setSelected((prev) => {
         const exists = prev.includes(tag);
         const updated = exists ? prev.filter((t) => t !== tag) : [...prev, tag];

--- a/src/components/commons/TagSelector.tsx
+++ b/src/components/commons/TagSelector.tsx
@@ -50,6 +50,7 @@ export default function TagSelector({
               className={clsx(
                 'box-border flex h-[2rem] items-center justify-center rounded-[0.5rem] border bg-[#34343a] pr-[0.5rem] pl-[0.75rem] text-sm font-medium text-gray-100',
                 isActive ? 'border-[#9747FF] shadow-md' : 'border-transparent',
+                mode === 'selectable' && 'cursor-pointer',
               )}
             >
               {tag}

--- a/src/components/commons/__tests__/TagSelector.test.tsx
+++ b/src/components/commons/__tests__/TagSelector.test.tsx
@@ -17,14 +17,14 @@ jest.mock('@/assets/icons/ic_check.svg', () => {
 const mockTags = ['보컬', '기타', '드럼'];
 describe('TagSelector', () => {
   test('모든 태그 버튼이 렌더링된다.', () => {
-    render(<TagSelector tags={mockTags} />);
+    render(<TagSelector mode="selectable" tags={mockTags} />);
     expect(screen.getByText('보컬')).toBeInTheDocument();
     expect(screen.getByText('기타')).toBeInTheDocument();
     expect(screen.getByText('드럼')).toBeInTheDocument();
   });
 
   test('클릭하면 선택되고, 다시 클릭하면 해제된다.', () => {
-    render(<TagSelector tags={mockTags} />);
+    render(<TagSelector mode="selectable" tags={mockTags} />);
     const guitarTagButton = screen.getByText('기타');
     expect(guitarTagButton.className).toContain('border-transparent');
     expect(guitarTagButton.className).not.toContain('border-[#9747FF]');
@@ -40,7 +40,9 @@ describe('TagSelector', () => {
 
   test('onChange가 호출된다.', () => {
     const handleChange = jest.fn();
-    render(<TagSelector tags={mockTags} onChange={handleChange} />);
+    render(
+      <TagSelector mode="selectable" tags={mockTags} onChange={handleChange} />,
+    );
     fireEvent.click(screen.getByText('드럼'));
     expect(handleChange).toHaveBeenCalledWith(['드럼']);
     fireEvent.click(screen.getByText('드럼'));
@@ -49,7 +51,9 @@ describe('TagSelector', () => {
 
   test('여러개의 태그가 잘 선택된다.', () => {
     const handleChange = jest.fn();
-    render(<TagSelector tags={mockTags} onChange={handleChange} />);
+    render(
+      <TagSelector mode="selectable" tags={mockTags} onChange={handleChange} />,
+    );
     const vocalButton = screen.getByText('보컬');
     const guitarButton = screen.getByText('기타');
     const drumButton = screen.getByText('드럼');
@@ -65,5 +69,35 @@ describe('TagSelector', () => {
 
     fireEvent.click(guitarButton);
     expect(handleChange).toHaveBeenLastCalledWith(['보컬', '드럼']);
+  });
+
+  test('readonly일 경우 readonlySelected에 포함된 태그가 선택돼있다.', () => {
+    render(
+      <TagSelector
+        tags={mockTags}
+        mode="readonly"
+        readonlySelected={['보컬']}
+      />,
+    );
+    const vocalTagButton = screen.getByText('보컬');
+    expect(vocalTagButton.className).toContain('border-[#9747FF]');
+    const guitarTagButton = screen.getByText('기타');
+    expect(guitarTagButton.className).toContain('border-transparent');
+    const drumTagButton = screen.getByText('드럼');
+    expect(drumTagButton.className).toContain('border-transparent');
+  });
+
+  test('readonly 모드에서는 선택해도 onChange가 호출되지 않는다.', () => {
+    const handleChange = jest.fn();
+    render(
+      <TagSelector
+        mode="readonly"
+        tags={mockTags}
+        readonlySelected={['보컬']}
+        onChange={handleChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('드럼'));
+    expect(handleChange).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 연관된 이슈

close #37

## 작업내용
모임 상세 페이지에 태그 선택 컴포넌트랑 같은 디자인인데, 선택은 안되고 이미 선택된 태그를 보여주는 UI도 있더라고요. 그래서 이 컴포넌트를 재사용 가능하게 리팩토링했습니다. 
- mode를 readonly, selectable로 분리했어요.
<img width="983" alt="스크린샷 2025-05-26 오전 10 52 44" src="https://github.com/user-attachments/assets/73721ffc-99a1-482b-a2a4-64be4b2ad78d" />

## 스크린샷
![화면 기록 2025-05-26 오전 10 49 13](https://github.com/user-attachments/assets/ad67ff99-7bfa-4396-bb62-3354a7988aad)
