### PR TITLE
[컴포넌트] Modal 리팩토링

### DIFF
--- a/src/assets/icons/ic_x.svg
+++ b/src/assets/icons/ic_x.svg
@@ -1,4 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M5 5L19.5 19.5" stroke="#111827" stroke-width="1.8" stroke-linecap="round"/>
-<path d="M19.5 5L5 19.5" stroke="#111827" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M5.5 5L18.5 18" stroke="#64748B" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M18.5 5L5.5 18" stroke="#64748B" stroke-width="1.8" stroke-linecap="round"/>
 </svg>

--- a/src/components/commons/Button.tsx
+++ b/src/components/commons/Button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
         solid:
           'bg-[#9900ff] text-white hover:bg-[#7a00cc] active:bg-[#6600a9] disabled:bg-gray-400',
         outline:
-          'bg-white border border-solid text-[#9900ff]border-[#9900ff] hover:border-[#7a00cc]hover:text-[#7a00cc] active:border-[#6600a9] active:text-[#6600a9]disabled:border-gray-400 disabled:text-gray-400',
+          'bg-white border border-solid text-[#9900ff] border-[#9900ff] hover:border-[#7a00cc]hover:text-[#7a00cc] active:border-[#6600a9] active:text-[#6600a9]disabled:border-gray-400 disabled:text-gray-400',
       },
       size: {
         large: 'w-[20.7rem]',

--- a/src/components/commons/Modal/ModalEdit.tsx
+++ b/src/components/commons/Modal/ModalEdit.tsx
@@ -86,16 +86,19 @@ export default function ModalEdit({
     <ModalWrapper
       title="프로필 수정하기"
       onClose={onCancel}
-      className="relative mx-auto max-h-[80vh] w-full max-w-md overflow-y-auto rounded-lg bg-white p-4 text-black shadow-lg"
+      className="relative h-auto w-[32.5rem] max-w-md overflow-y-auto rounded-lg bg-[#242429] p-[1.5rem]"
     >
       <FormProvider {...methods}>
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="flex flex-col gap-[1.5rem]"
+        >
           <ProfileImageUpload
             imageFile={imageFile}
             onFileChange={handleFileChange}
           />
 
-          <div className="flex flex-col gap-4 pb-4">
+          <div className="flex flex-col gap-[1.5rem]">
             {tagSections.map(
               ({ key, label, tags, initialSelected, onChange }) => (
                 <TagSection

--- a/src/components/commons/Modal/ModalInteraction.tsx
+++ b/src/components/commons/Modal/ModalInteraction.tsx
@@ -21,10 +21,12 @@ export default function ModalInteraction({
   return (
     <ModalWrapper
       onClose={onClose}
-      className="relative w-full bg-white p-6 text-black"
+      className="relative h-[212px] w-[450px] rounded-lg bg-[#242429] p-[24px] text-gray-100"
     >
-      <p className="text-center whitespace-pre-line">{message}</p>
-      <div className="mt-6 flex justify-center gap-3">
+      <p className="mt-[48px] text-center text-base font-medium whitespace-pre-line">
+        {message}
+      </p>
+      <div className="mt-[24px] flex justify-center gap-3">
         {isShowCancel && (
           <Button variant="outline" size="small" onClick={onClose}>
             취소

--- a/src/components/commons/Modal/ModalInteraction.tsx
+++ b/src/components/commons/Modal/ModalInteraction.tsx
@@ -21,12 +21,12 @@ export default function ModalInteraction({
   return (
     <ModalWrapper
       onClose={onClose}
-      className="relative h-[212px] w-[450px] rounded-lg bg-[#242429] p-[24px] text-gray-100"
+      className="relative h-[13.25rem] w-[28.125rem] rounded-lg bg-[#242429] p-[1.5rem] text-gray-100"
     >
-      <p className="mt-[48px] text-center text-base font-medium whitespace-pre-line">
+      <p className="mt-[3rem] text-center text-base font-medium whitespace-pre-line">
         {message}
       </p>
-      <div className="mt-[24px] flex justify-center gap-3">
+      <div className="mt-[1.5rem] flex justify-center gap-3">
         {isShowCancel && (
           <Button variant="outline" size="small" onClick={onClose}>
             취소

--- a/src/components/commons/Modal/ModalReview.tsx
+++ b/src/components/commons/Modal/ModalReview.tsx
@@ -60,12 +60,15 @@ export default function ModalReview({ onCancel, onSubmit }: ModalReviewProps) {
     <ModalWrapper
       title="리뷰쓰기"
       onClose={onCancel}
-      className="relative w-full bg-white p-6 text-black"
+      className="relative h-auto w-[32.5rem] bg-[#242429] p-[1.5rem] text-gray-100"
     >
       <FormProvider {...methods}>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-2">
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="flex flex-col gap-[2rem]"
+        >
+          <div className="flex flex-col gap-[2rem]">
+            <div className="flex flex-col gap-[0.75rem]">
               <p className="text-lg font-semibold">만족스러운 경험이었나요?</p>
               <Controller
                 name="rating"
@@ -80,24 +83,21 @@ export default function ModalReview({ onCancel, onSubmit }: ModalReviewProps) {
               />
             </div>
 
-            <div className="flex flex-col gap-2">
-              <p className="text-lg font-semibold">어떤 사람인가요?</p>
-              <div className="flex flex-col gap-1">
-                {tagSections.map(
-                  ({ key, label, tags, initialSelected, onChange }) => (
-                    <TagSection
-                      key={key}
-                      label={label}
-                      tags={tags}
-                      initialSelected={initialSelected}
-                      onChange={onChange}
-                    />
-                  ),
-                )}
+            <div className="flex flex-col gap-[0.75rem]">
+              <div className="flex flex-col gap-[0.5rem]">
+                {tagSections.map(({ key, tags, initialSelected, onChange }) => (
+                  <TagSection
+                    key={key}
+                    label={'##님과의 합주 경험은 어땠나요?'} // TODO: API 사용자 정보 불러와서 교체 필요
+                    tags={tags}
+                    initialSelected={initialSelected}
+                    onChange={onChange}
+                  />
+                ))}
               </div>
             </div>
 
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-[0.75rem]">
               <p className="text-lg font-semibold">
                 경험에 대해 자유롭게 남겨주세요.(선택)
               </p>

--- a/src/components/commons/Modal/ModalReview.tsx
+++ b/src/components/commons/Modal/ModalReview.tsx
@@ -60,7 +60,7 @@ export default function ModalReview({ onCancel, onSubmit }: ModalReviewProps) {
     <ModalWrapper
       title="리뷰쓰기"
       onClose={onCancel}
-      className="relative h-auto w-[32.5rem] bg-[#242429] p-[1.5rem] text-gray-100"
+      className="relative h-auto w-[32.5rem] rounded-lg bg-[#242429] p-[1.5rem] text-gray-100"
     >
       <FormProvider {...methods}>
         <form

--- a/src/components/commons/Modal/ModalWrapper.tsx
+++ b/src/components/commons/Modal/ModalWrapper.tsx
@@ -34,7 +34,9 @@ function ModalWrapper({
         >
           <CancelIcon />
         </button>
-        {title && <h2 className="font- mb-4 text-xl font-bold">{title}</h2>}
+        {title && (
+          <h2 className="mb-4 text-lg font-semibold text-gray-100">{title}</h2>
+        )}
         {children}
       </div>
     </div>

--- a/src/components/commons/Modal/ModalWrapper.tsx
+++ b/src/components/commons/Modal/ModalWrapper.tsx
@@ -35,7 +35,9 @@ function ModalWrapper({
           <CancelIcon />
         </button>
         {title && (
-          <h2 className="mb-4 text-lg font-semibold text-gray-100">{title}</h2>
+          <h2 className="mb-[2rem] text-lg font-semibold text-gray-100">
+            {title}
+          </h2>
         )}
         {children}
       </div>

--- a/src/components/commons/TagSection.tsx
+++ b/src/components/commons/TagSection.tsx
@@ -16,7 +16,7 @@ function TagSection({
 }: TagSectionProps) {
   return (
     <div className="flex flex-col gap-2">
-      <p className="pt-2 text-lg font-semibold">{label}</p>
+      <p className="pt-2 text-lg font-semibold text-gray-100">{label}</p>
       <div className="flex flex-col gap-1">
         <TagSelector
           mode="selectable"

--- a/src/components/commons/__tests__/ModalReview.test.tsx
+++ b/src/components/commons/__tests__/ModalReview.test.tsx
@@ -15,7 +15,6 @@ describe('ModalReview 렌데링 테스트', () => {
     render(<ModalReview onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
     expect(screen.getByText('리뷰쓰기')).toBeInTheDocument();
     expect(screen.getByText('만족스러운 경험이었나요?')).toBeInTheDocument();
-    expect(screen.getByText('어떤 사람인가요?')).toBeInTheDocument();
     expect(
       screen.getByText('경험에 대해 자유롭게 남겨주세요.(선택)'),
     ).toBeInTheDocument();


### PR DESCRIPTION
## 연관된 이슈

close #76 

## 작업내용
- 모달 피그마 시안 적용(색상과 폰트가 하나 만들어주신거랑 비슷할 것 같아서 미리 적용)
- 버튼에서 띄어쓰기가 안되어있어서 수정

## 체크리스트
- @euoonw  프로필 수정을 위한 버튼 크기가 472px가 필요한데, 아직 피그마 시안 확정 아니니까 확정나면 버튼 크기 하나 추가해주세요.
- 레이아웃 위주로 봐주시면 됩니다.
- 폰트 크기같은 경우는 계속 수정중인것 같아 보기 좋게 구분만 되게 해놨어요.

## 스크린샷
- 상호작용1
<img width="599" alt="스크린샷 2025-06-03 오후 3 16 04" src="https://github.com/user-attachments/assets/1b2074e8-8f01-4601-8e74-ed3f02e5efaa" />

- 상호작용2
<img width="511" alt="스크린샷 2025-06-03 오후 3 16 20" src="https://github.com/user-attachments/assets/4927e4ae-e99b-4f17-ad9d-4861eeb45cca" />

- 프로필수정
<img width="525" alt="스크린샷 2025-06-03 오후 3 16 46" src="https://github.com/user-attachments/assets/d4a2f349-07c3-4e02-85b9-89822ed82c8d" />

- 리뷰
<img width="581" alt="스크린샷 2025-06-03 오후 3 17 49" src="https://github.com/user-attachments/assets/e09ea80c-3139-4b0b-87a3-7ef8e915bf63" />
