### PR TITLE
[기능] 회원가입 유효성 검사 보완, 이메일 중복 검사 추가

### DIFF
--- a/src/components/products/signup/step1/SignupStep1Page.tsx
+++ b/src/components/products/signup/step1/SignupStep1Page.tsx
@@ -4,8 +4,16 @@ import AuthCard from '@/components/commons/AuthCard';
 import Button from '@/components/commons/Button';
 import Input from '@/components/commons/Input';
 import { useSignupStore } from '@/stores/useSignupStore';
-import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import {
+  FormProvider,
+  SubmitHandler,
+  useForm,
+  useWatch,
+} from 'react-hook-form';
 import { useRouter } from 'next/navigation';
+import debounce from 'lodash.debounce';
+import { useEffect, useState } from 'react';
+import { checkEmailDuplicate } from '@/lib/auth/signup';
 
 interface FormValues {
   email: string;
@@ -23,9 +31,51 @@ export default function SignUpStep1Page() {
   const {
     formState: { isValid },
     watch,
+    setError,
+    clearErrors,
   } = methods;
 
+  const email = useWatch({ name: 'email', control: methods.control });
   const password = watch('password');
+  const [checking, setChecking] = useState(false);
+  const [isDuplicate, setIsDuplicate] = useState<boolean | null>(null);
+  const [duplicateMessage, setDuplicateMessage] = useState<string | null>(null);
+  const isValidEmailFormat = (email: string) =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+  useEffect(() => {
+    if (!email) {
+      setDuplicateMessage(null);
+      return;
+    }
+    const isValidFormat = isValidEmailFormat(email);
+    if (!isValidFormat) {
+      setDuplicateMessage(null);
+      setIsDuplicate(null);
+      return;
+    }
+
+    const debounceCheck = debounce(async (emailToCheck: string) => {
+      setChecking(true);
+      try {
+        const exists = await checkEmailDuplicate(emailToCheck);
+        setIsDuplicate(exists);
+        if (exists) {
+          setDuplicateMessage('이미 사용 중인 이메일입니다.');
+        } else {
+          setDuplicateMessage('사용 가능한 이메일입니다.');
+        }
+      } catch {
+        setDuplicateMessage('중복 검사 중 오류가 발생했습니다.');
+        setIsDuplicate(null);
+      } finally {
+        setChecking(false);
+      }
+    }, 500);
+
+    debounceCheck(email);
+    return () => debounceCheck.cancel();
+  }, [email, setError, clearErrors]);
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     useSignupStore.getState().setStep1Data(data);
@@ -42,19 +92,30 @@ export default function SignUpStep1Page() {
             className="w-full"
           >
             <div className="flex flex-col gap-[1.5rem]">
-              <Input
-                name="email"
-                type="text"
-                label="아이디"
-                placeholder="이메일을 입력해주세요."
-                rules={{
-                  required: '이메일은 필수 입력입니다.',
-                  pattern: {
-                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-                    message: '올바른 이메일 형식을 입력해주세요.',
-                  },
-                }}
-              />
+              <div>
+                <Input
+                  name="email"
+                  type="text"
+                  label="아이디"
+                  placeholder="이메일을 입력해주세요."
+                  rules={{
+                    required: '이메일은 필수 입력입니다.',
+                    pattern: {
+                      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                      message: '올바른 이메일 형식을 입력해주세요.',
+                    },
+                  }}
+                />
+                {duplicateMessage && (
+                  <p
+                    className={`mt-3 text-sm ${
+                      isDuplicate ? 'text-red-500' : 'text-[#bf5eff]'
+                    }`}
+                  >
+                    {duplicateMessage}
+                  </p>
+                )}
+              </div>
               <Input
                 name="name"
                 type="text"
@@ -94,9 +155,9 @@ export default function SignUpStep1Page() {
               size="large"
               className="mt-[2.5rem] w-full"
               type="submit"
-              disabled={!isValid}
+              disabled={!isValid || checking || isDuplicate === true}
             >
-              다음
+              {checking ? '확인 중...' : '다음'}
             </Button>
           </form>
         </FormProvider>

--- a/src/components/products/signup/step2/SignupStep2Page.tsx
+++ b/src/components/products/signup/step2/SignupStep2Page.tsx
@@ -7,7 +7,7 @@ import ProfileImageUpload from '@/components/commons/ProfileImageUpload';
 import TagSection from '@/components/commons/TagSection';
 import { GENRE_TAGS, SESSION_TAGS } from '@/constants/tags';
 import { useSignupStore } from '@/stores/useSignupStore';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import {
   Controller,
   FormProvider,
@@ -28,6 +28,15 @@ interface FormValues {
 export default function SignupStep2Page() {
   const router = useRouter();
   const { email, name, password } = useSignupStore();
+
+  useEffect(() => {
+    if (!email || !name || !password) {
+      // TODO: 모달 반영
+      alert('이전 단계 정보를 확인할 수 없어, 다시 입력이 필요합니다.');
+      router.replace('/signup/step1');
+    }
+  }, []);
+
   const methods = useForm<FormValues>({
     mode: 'all',
     defaultValues: { image: undefined, nickname: '', session: [], genre: [] },
@@ -75,6 +84,15 @@ export default function SignupStep2Page() {
   const { mutateAsync } = useSignupMutation();
 
   const onSubmit: SubmitHandler<FormValues> = async (data) => {
+    if (!email || !name || !password) {
+      // TODO: 모달 반영
+      alert(
+        '이메일, 이름, 비밀번호 정보가 유실되었습니다.\n다시 회원가입을 진행해주세요.',
+      );
+      router.replace('/signup/step1');
+      return;
+    }
+
     const preferredGenres = data.genre.map((kr) => GENRE_KR_TO_ENUM[kr]);
     const preferredBandSessions = data.session.map(
       (kr) => SESSION_KR_TO_ENUM[kr],
@@ -94,7 +112,7 @@ export default function SignupStep2Page() {
 
     useSignupStore.getState().resetSignupData();
     reset();
-    router.push('/signup/step1');
+    router.push('/login');
   };
 
   return (

--- a/src/constants/tagsMapping.ts
+++ b/src/constants/tagsMapping.ts
@@ -1,8 +1,8 @@
 import { Genre, BandSession } from '@/types/tags';
 
 export const GENRE_KR_TO_ENUM: Record<string, Genre> = {
-  락: Genre.ROCK_METAL,
-  메탈: Genre.ROCK_METAL, // 락, 메탈 일단 동일하게 설정
+  락: Genre.ROCK,
+  메탈: Genre.METAL,
   팝: Genre.POP,
   발라드: Genre.BALLAD,
   'R&B': Genre.RNB,

--- a/src/constants/tagsMapping.ts
+++ b/src/constants/tagsMapping.ts
@@ -19,7 +19,7 @@ export const SESSION_KR_TO_ENUM: Record<string, BandSession> = {
   일렉기타: BandSession.ELECTRIC_GUITAR,
   통기타: BandSession.ACOUSTIC_GUITAR,
   베이스: BandSession.BASS,
-  // '건반': BandSession.KEYBOARD, <- 추가 필요
+  건반: BandSession.KEYBOARD,
   드럼: BandSession.DRUM,
   타악기: BandSession.PERCUSSION,
   현악기: BandSession.STRING_INSTRUMENT,

--- a/src/hooks/queries/user/useUserMeQuery.ts
+++ b/src/hooks/queries/user/useUserMeQuery.ts
@@ -5,7 +5,7 @@ export const useUserMeQuery = () =>
   useQuery({
     queryKey: ['me'], // Query Key Factory 사용 고민 필요
     queryFn: async () => {
-      const response = await instance.get('/jammit/user');
+      const response = await instance.get('/user');
       const data = response.data;
 
       if ('success' in data && !data.success) {

--- a/src/lib/auth/login.ts
+++ b/src/lib/auth/login.ts
@@ -4,16 +4,13 @@ export async function postLogin({
   email,
   password,
 }: LoginRequest): Promise<LoginResponse> {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL}/jammit/auth/login`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ email, password }),
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
     },
-  );
+    body: JSON.stringify({ email, password }),
+  });
 
   const data = await res.json();
 

--- a/src/lib/auth/signup.ts
+++ b/src/lib/auth/signup.ts
@@ -20,3 +20,14 @@ export const postSignup = async (
 
   return json.result;
 };
+
+export const checkEmailDuplicate = async (email: string) => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/jammit/user/exists?email=${encodeURIComponent(email)}`,
+    { method: 'GET' },
+  );
+  if (!res.ok) throw new Error('이메일 중복 확인에 실패했습니다');
+  const data = await res.json();
+  console.log('data', data);
+  return data.result.exists as boolean;
+};

--- a/src/lib/auth/signup.ts
+++ b/src/lib/auth/signup.ts
@@ -3,7 +3,7 @@ import { SignupRequest, SignupResponse } from '@/types/auth';
 export const postSignup = async (
   data: SignupRequest,
 ): Promise<SignupResponse['result']> => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/jammit/user`, {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/user`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -23,11 +23,12 @@ export const postSignup = async (
 
 export const checkEmailDuplicate = async (email: string) => {
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL}/jammit/user/exists?email=${encodeURIComponent(email)}`,
+    `${process.env.NEXT_PUBLIC_API_URL}/user/exists?email=${encodeURIComponent(email)}`,
     { method: 'GET' },
   );
-  if (!res.ok) throw new Error('이메일 중복 확인에 실패했습니다');
+  if (!res.ok) {
+    throw new Error('이메일 중복 확인에 실패했습니다');
+  }
   const data = await res.json();
-  console.log('data', data);
   return data.result.exists as boolean;
 };

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -1,5 +1,6 @@
 export enum Genre {
-  ROCK_METAL = 'ROCK_METAL', //락, 메탈 분리 필요
+  ROCK = 'ROCK',
+  METAL = 'METAL',
   POP = 'POP',
   BALLAD = 'BALLAD',
   INDIE = 'INDIE',

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -21,5 +21,5 @@ export enum BandSession {
   BASS = 'BASS',
   STRING_INSTRUMENT = 'STRING_INSTRUMENT',
   PERCUSSION = 'PERCUSSION',
-  //건반 추가 필요
+  KEYBOARD = 'KEYBOARD',
 }


### PR DESCRIPTION
## 연관된 이슈

close #83 

## 작업내용
- 락/메탈 장르 분리, 세션에 건반 추가
- 회원가입 step2 페이지에서 새로고침 시, "이전 단계 정보를 확인할 수 없어, 다시 입력이 필요합니다" alert띄우고 step1 페이지로 이동
- 회원가입 step2 페이지에서 이전 페이지 정보가 누락된 상태로 회원가입 시도했을 때, "이메일, 이름, 비밀번호 정보가 유실되었습니다. 다시 회원가입을 진행해주세요." alert 띄우로 step1 페이지로 이동
- 이메일 중복검사 (입력이 멈춘 후 500ms 동안 추가 입력이 없을 경우 자동으로 중복 검사를 수행)

## 체크리스트
- 모달은 브랜치 따로 파서 한번에 적용할게요! 

## 스크린샷

https://github.com/user-attachments/assets/88fc1041-4fc7-49b3-8cff-b5b6abec6402


