### PR TITLE
[기능] 유저 정보 전역상태 관리 로직 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   images: {
+    domains: ['torip.s3.ap-northeast-2.amazonaws.com'],
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/components/commons/Gnb.tsx
+++ b/src/components/commons/Gnb.tsx
@@ -6,8 +6,8 @@ import DefaultProfileImage from '@/assets/icons/ic_default_profile.svg';
 import JammitLogo from '@/assets/icons/ic_jammit_logo.svg';
 import Dropdown from '@/components/commons/Dropdown';
 import { useRouter } from 'next/navigation';
-import { useUserMeQuery } from '@/hooks/queries/user/useUserMeQuery';
 import { logout } from '@/utils/authService';
+import { useUserStore } from '@/stores/useUserStore';
 
 const PROFILE_OPTIONS = ['마이페이지', '로그아웃'];
 
@@ -15,8 +15,8 @@ export default function Gnb() {
   const router = useRouter();
   const pathname = usePathname();
 
-  const { data: user, isError, isLoading } = useUserMeQuery();
-  const isLoggedIn = !!user && !isError && !isLoading;
+  const user = useUserStore((state) => state.user);
+  const isLoggedIn = !!user;
 
   const navItems = [
     { href: '/', label: '모임 찾기' },

--- a/src/components/commons/Gnb.tsx
+++ b/src/components/commons/Gnb.tsx
@@ -2,12 +2,12 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import DefaultProfileImage from '@/assets/icons/ic_default_profile.svg';
 import JammitLogo from '@/assets/icons/ic_jammit_logo.svg';
 import Dropdown from '@/components/commons/Dropdown';
 import { useRouter } from 'next/navigation';
 import { logout } from '@/utils/authService';
 import { useUserStore } from '@/stores/useUserStore';
+import ProfileImage from './ProfileImage';
 
 const PROFILE_OPTIONS = ['마이페이지', '로그아웃'];
 
@@ -16,7 +16,7 @@ export default function Gnb() {
   const pathname = usePathname();
 
   const user = useUserStore((state) => state.user);
-  const isLoggedIn = !!user;
+  const isLoggedIn = useUserStore((state) => state.isLoggedIn);
 
   const navItems = [
     { href: '/', label: '모임 찾기' },
@@ -60,7 +60,7 @@ export default function Gnb() {
               <Dropdown
                 menuOptions={PROFILE_OPTIONS}
                 onSelect={handleProfileSelect}
-                singleIcon={<DefaultProfileImage width={40} height={40} />}
+                singleIcon={<ProfileImage src={user?.profileImagePath} />}
                 isProfile
               />
             ) : (

--- a/src/components/commons/ProfileImage.tsx
+++ b/src/components/commons/ProfileImage.tsx
@@ -1,39 +1,50 @@
 'use client';
 
 import DefaultProfileImage from '@/assets/icons/ic_default_profile.svg';
+import clsx from 'clsx';
 import Image from 'next/image';
 import { useState } from 'react';
 
 interface ProfileImageProps {
   src?: string | null;
   alt?: string;
-  size?: number;
+  size?: number; // 단위: rem
   className?: string;
 }
 
 export default function ProfileImage({
   src,
   alt = '프로필 이미지',
-  size = 40,
+  size = 2.5,
   className,
 }: ProfileImageProps) {
   const [hasError, setHasError] = useState(false);
-  const commonStyle = `rounded-full object-cover ${className ?? ''}`;
+  const commonStyle = clsx('rounded-full object-cover', className);
+  const pxSize = size * 16;
 
   if (!src || hasError) {
     return (
-      <DefaultProfileImage width={size} height={size} className={commonStyle} />
+      <DefaultProfileImage
+        width={pxSize}
+        height={pxSize}
+        className={commonStyle}
+      />
     );
   }
 
   return (
-    <Image
-      src={src}
-      alt={alt}
-      width={size}
-      height={size}
-      className={commonStyle}
-      onError={() => setHasError(true)}
-    />
+    <div
+      style={{ width: `${size}rem`, height: `${size}rem` }}
+      className={clsx('relative overflow-hidden rounded-full', className)}
+    >
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        sizes={`${size}rem`}
+        className={commonStyle}
+        onError={() => setHasError(true)}
+      />
+    </div>
   );
 }

--- a/src/components/commons/ProfileImage.tsx
+++ b/src/components/commons/ProfileImage.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import DefaultProfileImage from '@/assets/icons/ic_default_profile.svg';
+import Image from 'next/image';
+import { useState } from 'react';
+
+interface ProfileImageProps {
+  src?: string | null;
+  alt?: string;
+  size?: number;
+  className?: string;
+}
+
+export default function ProfileImage({
+  src,
+  alt = '프로필 이미지',
+  size = 40,
+  className,
+}: ProfileImageProps) {
+  const [hasError, setHasError] = useState(false);
+  const commonStyle = `rounded-full object-cover ${className ?? ''}`;
+
+  if (!src || hasError) {
+    return (
+      <DefaultProfileImage width={size} height={size} className={commonStyle} />
+    );
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={size}
+      height={size}
+      className={commonStyle}
+      onError={() => setHasError(true)}
+    />
+  );
+}

--- a/src/components/products/login/LoginPage.tsx
+++ b/src/components/products/login/LoginPage.tsx
@@ -6,7 +6,6 @@ import Input from '@/components/commons/Input';
 import { useLoginMutation } from '@/hooks/queries/auth/useLoginMutaion';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
-import { queryClient } from '@/lib/react-query';
 
 interface FormValues {
   email: string;
@@ -30,7 +29,6 @@ export default function LoginPage() {
   const onSubmit: SubmitHandler<FormValues> = async (data) => {
     await mutateAsync(data);
     router.push('/');
-    queryClient.invalidateQueries({ queryKey: ['me'] });
     reset();
   };
 

--- a/src/hooks/queries/user/useUserMeQuery.ts
+++ b/src/hooks/queries/user/useUserMeQuery.ts
@@ -1,9 +1,23 @@
 import { getUserMe } from '@/lib/user/user';
+import { useUserStore } from '@/stores/useUserStore';
+import { UserResponse } from '@/types/user';
 import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 
-export const useUserMeQuery = () =>
-  useQuery({
+export const useUserMeQuery = () => {
+  const setUser = useUserStore((state) => state.setUser);
+
+  const query = useQuery<UserResponse>({
     queryKey: ['me'],
     queryFn: getUserMe,
     retry: true,
   });
+
+  useEffect(() => {
+    if (query.data) {
+      setUser(query.data);
+    }
+  }, [query.data, setUser]);
+
+  return query;
+};

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -4,6 +4,7 @@ import { UserResponse } from '@/types/user';
 
 interface UserState {
   user: UserResponse | null;
+  isLoggedIn: boolean;
   setUser: (user: UserResponse) => void;
   clearUser: () => void;
 }
@@ -12,8 +13,9 @@ export const useUserStore = create<UserState>()(
   persist(
     (set) => ({
       user: null,
-      setUser: (user) => set({ user }),
-      clearUser: () => set({ user: null }),
+      isLoggedIn: false,
+      setUser: (user) => set({ user, isLoggedIn: true }),
+      clearUser: () => set({ user: null, isLoggedIn: false }),
     }),
     {
       name: 'user',

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { UserResponse } from '@/types/user';
+
+interface UserState {
+  user: UserResponse | null;
+  setUser: (user: UserResponse) => void;
+  clearUser: () => void;
+}
+
+export const useUserStore = create<UserState>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: 'user',
+    },
+  ),
+);

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -4,11 +4,17 @@ import { postLogin } from '@/lib/auth/login';
 import { postSignup } from '@/lib/auth/signup';
 import { queryClient } from '@/lib/react-query';
 import { apiClient } from './apiClient';
+import { useUserStore } from '@/stores/useUserStore';
 
 export const login = async (loginRequest: LoginRequest): Promise<void> => {
-  const { accessToken, refreshToken } = await postLogin(loginRequest);
-  tokenService.setAccessToken(accessToken);
-  tokenService.setRefreshToken(refreshToken);
+  const result = await postLogin(loginRequest);
+
+  tokenService.setAccessToken(result.accessToken);
+  tokenService.setRefreshToken(result.refreshToken);
+
+  useUserStore.getState().setUser(result.user);
+
+  queryClient.invalidateQueries({ queryKey: ['me'] });
 };
 
 export const signup = async (signupRequest: SignupRequest): Promise<void> => {
@@ -16,6 +22,7 @@ export const signup = async (signupRequest: SignupRequest): Promise<void> => {
 };
 
 export const logout = async (): Promise<void> => {
+  useUserStore.getState().clearUser();
   tokenService.clearAllTokens();
   queryClient.invalidateQueries({ queryKey: ['me'] });
 };


### PR DESCRIPTION
## 연관된 이슈

close #96 

## 작업내용
- 사용자 프로필 정보, 로그인 여부 store에 저장
- 로그인하거나 사용자 정보 받아오면 store에 저장된 정보 업데이트
- 로그아웃하면 store 초기화
- 제가 사용하는 페이지들에 필요해서 프로필이미지 컴포넌트 만들었는데, 필요하시면 사용하세요!
   - 이미지 주소, 이미지 사이즈 받아서 보여줌
   - 이미지 주소가 null 이거나 유효한 주소가 아닐 경우 디폴트이미지 보여줌

## 체크리스트
- 사용자 프로필 정보를 수정할 때, store 정보 업데이트 되도록 적용해주세요!
### 사용법
정보 가져오기
```ts
import { useUserStore } from '@/stores/useUserStore';
// 이렇게
const user = useUserStore((state) => state.user);
const isLoggedIn = useUserStore((state) => state.isLoggedIn);

// 혹은 이렇게
const { user, isLoggedIn } = useUserStore();
```

정보 저장
```ts
import { useUserStore } from '@/stores/useUserStore';

const setUser = useUserStore.getState().setUser;

// 데이터 받아옴 (userData는 UserResponse 타입의 객체)
setUser(userData);
```

## 코멘트
store로 정보를 가져오니까 로그인 뒤에 gnb 프로필 반영이 더 빨라졌어요 😁