### PR TITLE
[버그] 모임 상세 비로그인시 참여멤버 탭만 접근 못하게 수정

### DIFF
--- a/src/hooks/queries/gatherings/useApproveParticipantMutation.ts
+++ b/src/hooks/queries/gatherings/useApproveParticipantMutation.ts
@@ -20,6 +20,9 @@ export const useApproveParticipantMutation = () => {
       queryClient.invalidateQueries({
         queryKey: ['gatheringDetail', gatheringId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['list'],
+      });
     },
     onError: (error) => {
       console.error('참가 승인 실패:', error);

--- a/src/hooks/queries/gatherings/useDeleteGatheringMutation.ts
+++ b/src/hooks/queries/gatherings/useDeleteGatheringMutation.ts
@@ -13,6 +13,9 @@ export const useDeleteGatheringMutation = () => {
         queryKey: ['gatheringParticipants', id],
       });
       queryClient.invalidateQueries({ queryKey: ['me', 'created'] });
+      queryClient.invalidateQueries({
+        queryKey: ['list'],
+      });
     },
     onError: (error) => {
       console.error('모임 취소 실패:', error);

--- a/src/hooks/queries/gatherings/useGatheringsParticipantsQuery.ts
+++ b/src/hooks/queries/gatherings/useGatheringsParticipantsQuery.ts
@@ -1,10 +1,15 @@
 import { getGatheringParticipants } from '@/lib/gatherings/gatherings';
-import { useQuery } from '@tanstack/react-query';
+import { ParticipantsResponse } from '@/types/gathering';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
-export const useGatheringParticipantsQuery = (id: number) => {
+export const useGatheringParticipantsQuery = (
+  id: number,
+  options?: Partial<UseQueryOptions<ParticipantsResponse>>,
+) => {
   return useQuery({
     queryKey: ['gatheringParticipants', id],
     queryFn: () => getGatheringParticipants(id),
     enabled: !!id,
+    ...options,
   });
 };


### PR DESCRIPTION
## 연관된 이슈

close #116

## 작업내용
- 원래 모임 상세 자체를 못보게 해놨었는데, 참여 멤버 탭만 접근 못하게 수정했어요

## 스크린샷
https://github.com/user-attachments/assets/9f702309-a670-4c49-879c-e351f8705751


## 스크린샷
