### PR TITLE
[페이지] 모임 수정 페이지

### DIFF
--- a/src/app/group/[groupId]/edit/page.tsx
+++ b/src/app/group/[groupId]/edit/page.tsx
@@ -3,15 +3,53 @@
 import { Suspense } from 'react';
 import { useParams } from 'next/navigation';
 import JamPage from '@/components/products/jam/JamPage';
+import { useGatheringDetailQuery } from '@/hooks/queries/gatherings/useGatheringsDetailQuery';
+import { RegisterGatheringsRequest } from '@/types/gather';
+import { GatheringDetailResponse } from '@/types/gathering';
+
+// GatheringDetailResponse를 RegisterGatheringsRequest로 변환하는 함수
+const transformDetailToFormData = (
+  detailData: GatheringDetailResponse,
+): RegisterGatheringsRequest => {
+  return {
+    name: detailData.name,
+    thumbnail: detailData.thumbnail,
+    place: detailData.place,
+    description: detailData.description,
+    gatheringDateTime: detailData.gatheringDateTime,
+    recruitDateTime: detailData.recruitDeadline,
+    genres: detailData.genres,
+    status: detailData.status,
+    totalRecruitCount:
+      detailData.sessions?.reduce(
+        (total, session) => total + (session.recruitCount || 0),
+        0,
+      ) || 0,
+    gatheringSessions:
+      detailData.sessions?.map((session) => ({
+        bandSession: session.bandSession,
+        recruitCount: session.recruitCount,
+      })) || [],
+  };
+};
 
 export default function EditPage() {
   const { groupId } = useParams();
+  const numericId = Number(groupId);
+  const { data: gatherDetailData } = useGatheringDetailQuery(numericId);
 
-  // get함수 가져오고 initialData 넣기
+  const initialData = gatherDetailData
+    ? transformDetailToFormData(gatherDetailData)
+    : undefined;
+  console.log('이니셜벨류', initialData);
 
   return (
     <Suspense fallback={'Loading...'}>
-      <JamPage formType="edit" groupId={Number(groupId)} />
+      <JamPage
+        formType="edit"
+        groupId={Number(groupId)}
+        initialData={initialData}
+      />
     </Suspense>
   );
 }

--- a/src/app/group/[groupId]/edit/page.tsx
+++ b/src/app/group/[groupId]/edit/page.tsx
@@ -1,7 +1,17 @@
 'use client';
+
+import { Suspense } from 'react';
 import { useParams } from 'next/navigation';
+import JamPage from '@/components/products/jam/JamPage';
 
 export default function EditPage() {
   const { groupId } = useParams();
-  return <> 모임 {groupId} 수정 페이지</>;
+
+  // get함수 가져오고 initialData 넣기
+
+  return (
+    <Suspense fallback={'Loading...'}>
+      <JamPage formType="edit" groupId={Number(groupId)} />
+    </Suspense>
+  );
 }

--- a/src/components/products/jam/ImageEdit.tsx
+++ b/src/components/products/jam/ImageEdit.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Button from '@/components/commons/Button';
 import ModalImgEdit from './ModalImgEdit';
 import { useFormContext } from 'react-hook-form';
@@ -10,7 +10,7 @@ import { imgChange } from '@/utils/imgChange';
 export default function ImageEdit() {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
-  const { setValue } = useFormContext<RegisterGatheringsRequest>();
+  const { setValue, watch } = useFormContext<RegisterGatheringsRequest>();
 
   const handleOpenModal = useCallback(() => {
     setIsOpen(true);
@@ -24,6 +24,13 @@ export default function ImageEdit() {
     },
     [setValue],
   );
+
+  useEffect(() => {
+    const thumb = watch('thumbnail');
+    if (thumb) {
+      setSelectedFileName(thumb);
+    }
+  }, [watch]);
 
   const selectedImageSrc = selectedFileName
     ? imgChange(selectedFileName, 'banner')

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -18,6 +18,7 @@ import { GENRE_TAGS, SESSION_KEY_MAP } from '@/constants/tags';
 import { GENRE_KR_TO_ENUM } from '@/constants/tagsMapping';
 import { RegisterGatheringsRequest } from '@/types/gather';
 import { GenreType } from '@/types/tags';
+import { formatDateToLocal } from '@/utils/formatDateToLocal';
 
 const DIVIDER = 'mx-auto my-[2.5rem] w-[56rem] border-gray-800';
 
@@ -159,7 +160,7 @@ export default function JamFormSection({
                       if (!date) {
                         return field.onChange('');
                       }
-                      field.onChange(date.toISOString());
+                      field.onChange(formatDateToLocal(date));
                     }}
                   />
                 )}

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   Control,
   UseFormWatch,
@@ -15,10 +15,11 @@ import { DatePicker } from '@/components/commons/DatePicker/DatePicker';
 import SearchInput from './SearchInput';
 import SessionSelector from './SessionSelector';
 import { GENRE_TAGS, SESSION_KEY_MAP } from '@/constants/tags';
-import { GENRE_KR_TO_ENUM } from '@/constants/tagsMapping';
+import { GENRE_KR_TO_ENUM, SESSION_ENUM_TO_KR } from '@/constants/tagsMapping';
 import { RegisterGatheringsRequest } from '@/types/gather';
 import { GenreType } from '@/types/tags';
 import { formatDateToLocal } from '@/utils/formatDateToLocal';
+import { useWatch } from 'react-hook-form';
 
 const DIVIDER = 'mx-auto my-[2.5rem] w-[56rem] border-gray-800';
 
@@ -89,6 +90,7 @@ export default function JamFormSection({
     [],
   );
 
+  // 세션 드롭다운 인원 변경
   const handleCountChange = useCallback(
     (index: number, newCount: number) => {
       setSessionList((prev) => {
@@ -120,6 +122,19 @@ export default function JamFormSection({
     },
     [setValue],
   );
+
+  const gatheringSessions = useWatch({ name: 'gatheringSessions' });
+
+  useEffect(() => {
+    if (gatheringSessions?.length) {
+      setSessionList(
+        gatheringSessions.map((s) => ({
+          sortOption: SESSION_ENUM_TO_KR[s.bandSession],
+          count: s.recruitCount,
+        })),
+      );
+    }
+  }, [gatheringSessions]);
 
   return (
     <div className="mt-[2.5rem] flex h-auto w-[61rem] flex-col bg-[#202024] p-[2.5rem]">
@@ -213,6 +228,12 @@ export default function JamFormSection({
             mode="selectable"
             tags={GENRE_TAGS}
             onChange={handleTagChange}
+            initialSelected={(watch('genres') || []).map(
+              (enumVal) =>
+                Object.keys(GENRE_KR_TO_ENUM).find(
+                  (k) => GENRE_KR_TO_ENUM[k] === enumVal,
+                ) || '',
+            )}
           />
         </div>
 

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -43,16 +43,26 @@ interface JamFormSectionProps {
   watch: UseFormWatch<RegisterGatheringsRequest>;
   /** 필드 값을 외부에서 설정 */
   setValue: UseFormSetValue<RegisterGatheringsRequest>;
+  /** 초기값 */
+  initialData?: RegisterGatheringsRequest;
 }
 
 export default function JamFormSection({
   control,
   watch,
   setValue,
+  initialData,
 }: JamFormSectionProps) {
-  const [sessionList, setSessionList] = useState([
-    { sortOption: '', count: 0 },
-  ]);
+  const [sessionList, setSessionList] = useState(() => {
+    if (initialData?.gatheringSessions?.length) {
+      return initialData.gatheringSessions.map((s) => ({
+        sortOption: SESSION_ENUM_TO_KR[s.bandSession] || '',
+        count: s.recruitCount,
+      }));
+    }
+    return [{ sortOption: '', count: 0 }];
+  });
+
   const place = watch('place') || '';
 
   // 빈 문자열 제외 이미 선택된 세션 옵션들을 계산
@@ -94,8 +104,8 @@ export default function JamFormSection({
   const handleCountChange = useCallback(
     (index: number, newCount: number) => {
       setSessionList((prev) => {
-        const newList = prev.map((sess, i) =>
-          i === index ? { ...sess, count: newCount } : sess,
+        const newList = prev.map((session, i) =>
+          i === index ? { ...session, count: newCount } : session,
         );
 
         setValue(
@@ -123,7 +133,7 @@ export default function JamFormSection({
     [setValue],
   );
 
-  const gatheringSessions = useWatch({ name: 'gatheringSessions' });
+  const gatheringSessions = useWatch({ name: 'gatheringSessions', control });
 
   useEffect(() => {
     if (gatheringSessions?.length) {

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -53,7 +53,7 @@ export default function JamPage({
 
   const onSubmit = (data: RegisterGatheringsRequest) => {
     if (formType === 'edit' && groupId) {
-      // edit put
+      // modify put
     } else {
       registerGathering(data);
       console.log(data);

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -7,6 +7,7 @@ import JamFormSection from '@/components/products/jam/JamFormSection';
 import { FormProvider, useForm } from 'react-hook-form';
 import { RegisterGatheringsRequest } from '@/types/gather';
 import { useGatherRegister } from '@/hooks/queries/gather/useGatherRegister';
+import { useEffect } from 'react';
 
 interface JamPageProps {
   formType?: 'register' | 'edit';
@@ -37,9 +38,16 @@ export default function JamPage({
     handleSubmit,
     control,
     watch,
+    reset,
     setValue,
     formState: { isValid },
   } = methods;
+
+  useEffect(() => {
+    if (initialData) {
+      reset(initialData);
+    }
+  }, [initialData, reset]);
 
   const { mutate: registerGathering } = useGatherRegister();
 
@@ -48,6 +56,7 @@ export default function JamPage({
       // edit put
     } else {
       registerGathering(data);
+      console.log(data);
     }
   };
 

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -72,10 +72,12 @@ export default function JamPage({
         description: data.description,
         gatheringSessions: data.gatheringSessions,
       });
+      // 지워!!
       console.log('이건 수정했을때', data);
       router.push(`/group/${groupId}`);
     } else {
       registerGathering(data);
+      // 지워!!
       console.log('이건 등록했을때', data);
     }
   };

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -99,7 +99,12 @@ export default function JamPage({
           }
           isTab={false}
         >
-          <JamFormSection control={control} watch={watch} setValue={setValue} />
+          <JamFormSection
+            control={control}
+            watch={watch}
+            setValue={setValue}
+            initialData={initialData}
+          />
         </GroupPageLayout>
       </form>
     </FormProvider>

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -1,13 +1,15 @@
 'use client';
 
+import { useEffect } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
 import ImageEdit from '@/components/products/jam/ImageEdit';
 import GroupPageLayout from '@/components/commons/GroupPageLayout';
 import Button from '@/components/commons/Button';
 import JamFormSection from '@/components/products/jam/JamFormSection';
-import { FormProvider, useForm } from 'react-hook-form';
 import { RegisterGatheringsRequest } from '@/types/gather';
 import { useGatherRegister } from '@/hooks/queries/gather/useGatherRegister';
-import { useEffect } from 'react';
+import { useGatherModify } from '@/hooks/queries/gather/useGatherModify';
 
 interface JamPageProps {
   formType?: 'register' | 'edit';
@@ -20,6 +22,7 @@ export default function JamPage({
   groupId,
   initialData,
 }: JamPageProps) {
+  const router = useRouter();
   const methods = useForm<RegisterGatheringsRequest>({
     defaultValues: initialData ?? {
       name: '',
@@ -50,13 +53,30 @@ export default function JamPage({
   }, [initialData, reset]);
 
   const { mutate: registerGathering } = useGatherRegister();
+  const { mutate: modifyGathering } = useGatherModify();
 
   const onSubmit = (data: RegisterGatheringsRequest) => {
     if (formType === 'edit' && groupId) {
-      // modify put
+      modifyGathering({
+        id: groupId,
+        name: data.name,
+        thumbnail: data.thumbnail,
+        place: data.place,
+        gatheringDateTime: data.gatheringDateTime,
+        totalRecruitCount: data.gatheringSessions.reduce(
+          (sum, session) => sum + session.recruitCount,
+          0,
+        ),
+        recruitDeadline: data.recruitDateTime,
+        genres: data.genres,
+        description: data.description,
+        gatheringSessions: data.gatheringSessions,
+      });
+      console.log('이건 수정했을때', data);
+      router.push(`/group/${groupId}`);
     } else {
       registerGathering(data);
-      console.log(data);
+      console.log('이건 등록했을때', data);
     }
   };
 

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -8,9 +8,19 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { RegisterGatheringsRequest } from '@/types/gather';
 import { useGatherRegister } from '@/hooks/queries/gather/useGatherRegister';
 
-export default function JamPage() {
+interface JamPageProps {
+  formType?: 'register' | 'edit';
+  groupId?: number;
+  initialData?: RegisterGatheringsRequest;
+}
+
+export default function JamPage({
+  formType = 'register',
+  groupId,
+  initialData,
+}: JamPageProps) {
   const methods = useForm<RegisterGatheringsRequest>({
-    defaultValues: {
+    defaultValues: initialData ?? {
       name: '',
       thumbnail: '',
       place: '',
@@ -34,7 +44,11 @@ export default function JamPage() {
   const { mutate: registerGathering } = useGatherRegister();
 
   const onSubmit = (data: RegisterGatheringsRequest) => {
-    registerGathering(data);
+    if (formType === 'edit' && groupId) {
+      // edit put
+    } else {
+      registerGathering(data);
+    }
   };
 
   return (
@@ -49,7 +63,7 @@ export default function JamPage() {
               type="submit"
               disabled={!isValid}
             >
-              모임 만들기
+              {formType === 'edit' ? '모임 수정하기' : '모임 만들기'}
             </Button>
           }
           isTab={false}

--- a/src/hooks/queries/gather/useGatherModify.ts
+++ b/src/hooks/queries/gather/useGatherModify.ts
@@ -2,7 +2,7 @@ import { putModifiedGatherings } from '@/lib/gathering/modified';
 import { handleAuthApiError } from '@/utils/authApiError';
 import { useMutation } from '@tanstack/react-query';
 
-export const useUpdateProfileImage = () =>
+export const useGatherModify = () =>
   useMutation({
     mutationFn: putModifiedGatherings,
 

--- a/src/hooks/queries/gather/useGatherModify.ts
+++ b/src/hooks/queries/gather/useGatherModify.ts
@@ -1,0 +1,14 @@
+import { putModifiedGatherings } from '@/lib/gathering/modified';
+import { handleAuthApiError } from '@/utils/authApiError';
+import { useMutation } from '@tanstack/react-query';
+
+export const useUpdateProfileImage = () =>
+  useMutation({
+    mutationFn: putModifiedGatherings,
+
+    onSuccess: () => {
+      alert('모임 수정 완료되었습니다.');
+    },
+
+    onError: (error) => handleAuthApiError(error, '모임 수정에 실패했습니다.'),
+  });

--- a/src/lib/gathering/created.ts
+++ b/src/lib/gathering/created.ts
@@ -15,6 +15,5 @@ export const getUserCreatedGatherings = async ({
   const result = await apiClient.get<GatheringsResponse>(
     `/gatherings/my/created?${query}`,
   );
-  console.log('이건 Create', result);
   return result;
 };

--- a/src/lib/gathering/modified.ts
+++ b/src/lib/gathering/modified.ts
@@ -1,0 +1,18 @@
+import { apiClient } from '@/utils/apiClient';
+import {
+  ModifiedGatheringsRequest,
+  ModifiedGatheringsResponse,
+} from '@/types/gather';
+
+export async function putModifiedGatherings({
+  id,
+  ...requestData
+}: {
+  id: number;
+} & ModifiedGatheringsRequest): Promise<ModifiedGatheringsResponse> {
+  const data = await apiClient.put<ModifiedGatheringsResponse>(
+    `/gatherings/${id}`,
+    requestData,
+  );
+  return data;
+}

--- a/src/lib/gathering/participants.ts
+++ b/src/lib/gathering/participants.ts
@@ -15,6 +15,5 @@ export const getUserParticipantsGatherings = async ({
   const result = await apiClient.get<GatheringsResponse>(
     `/gatherings/{gatheringId}/participants/my?${query}`,
   );
-  console.log('이건 participants', result);
   return result;
 };

--- a/src/types/gather.ts
+++ b/src/types/gather.ts
@@ -38,3 +38,39 @@ export interface RegisterGatheringsResponse {
   thumbnail: string;
   status: GatheringStatus;
 }
+
+export interface ModifiedGatheringsRequest {
+  name: string;
+  thumbnail: string;
+  place: string;
+  gatheringDateTime: string;
+  totalRecruitCount: number;
+  recruitDeadline: string;
+  genres: GenreType[];
+  description: string;
+  gatheringSessions: {
+    bandSession: BandSessionType;
+    recruitCount: number;
+  }[];
+}
+
+export interface ModifiedGatheringsResponse {
+  id: number;
+  name: string;
+  thumbnail: string;
+  place: string;
+  description: string;
+  gatheringDateTime: string;
+  recruitDeadline: string;
+  status: GatheringStatus;
+  genres: GenreType[];
+  sessions: {
+    bandSession: BandSessionType;
+    recruitCount: number;
+    currentCount: number;
+  }[];
+  creator: {
+    id: number;
+    nickname: string;
+  };
+}

--- a/src/utils/formatDateToLocal.ts
+++ b/src/utils/formatDateToLocal.ts
@@ -1,0 +1,9 @@
+export const formatDateToLocal = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+};


### PR DESCRIPTION
## 연관된 이슈

close #121 

## 작업내용
- jampage 인터페이스 통일
- 모임 수정 api 연동
- 수정 페이지일시 초기값 받아 렌더링

## 체크리스트
- 인터페이스가 안맞는 부분이 많아서 강제 변환시켜서 한 부분이 있어요. 일단 백엔드쪽에 이름(recruitDeadline <-> recruitDateTime)와 같은 것들 이름 통일과 누락한 부분 요청을 해야될 것 같아요. 지금은 구현하려고 강제로 했지만 요청 후 수정되면 반영하도록 할게요.

## 스크린샷
- 모임 생성
<img width="708" alt="스크린샷 2025-06-11 오후 1 39 24" src="https://github.com/user-attachments/assets/e36ba89c-8f9b-4993-b12b-2a67d3ae58f0" />

- 모임 생성 완료
<img width="717" alt="스크린샷 2025-06-11 오후 1 39 37" src="https://github.com/user-attachments/assets/3867a9e2-fec4-44f9-9b61-b7e411d67297" />

- 모임 수정(기존 내용)
<img width="697" alt="스크린샷 2025-06-11 오후 1 39 45" src="https://github.com/user-attachments/assets/9517d997-cbbd-4177-a103-f5b646c7d236" />

- 모임 수정(내용 수정)
<img width="704" alt="스크린샷 2025-06-11 오후 1 40 28" src="https://github.com/user-attachments/assets/83c1294d-acd2-427b-87a4-03e4db4a25c6" />

- 모임 수정 완료
![Uploading 스크린샷 2025-06-11 오후 1.40.34.png…]()

