### PR TITLE
[페이지] 마이페이지 모임 카드 무한스크롤 적용 

### DIFF
--- a/src/app/group/[groupId]/edit/page.tsx
+++ b/src/app/group/[groupId]/edit/page.tsx
@@ -38,9 +38,11 @@ export default function EditPage() {
   const numericId = Number(groupId);
   const { data: gatherDetailData } = useGatheringDetailQuery(numericId);
 
-  const initialData = gatherDetailData
-    ? transformDetailToFormData(gatherDetailData)
-    : undefined;
+  if (!gatherDetailData) {
+    return null;
+  }
+
+  const initialData = transformDetailToFormData(gatherDetailData);
 
   return (
     <Suspense fallback={'Loading...'}>

--- a/src/components/products/mypage/MyPageContent.tsx
+++ b/src/components/products/mypage/MyPageContent.tsx
@@ -1,17 +1,15 @@
 'use client';
 
 import clsx from 'clsx';
-import { useMemo, useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQueryTab } from '@/hooks/useQueryTab';
 import UserCard from '@/components/products/mypage/UserCard';
-import Created from '@/components/products/mypage/gather/Created';
 import ReviewsReceived from '@/components/products/mypage/review/ReviewsReceived';
 import ReviewsToWrite from '@/components/products/mypage/towrite/ReviewsToWrite';
-import { useGatherMeCreate } from '@/hooks/queries/gather/useGatherMeCreate';
 import { useReviewToWriteInfiniteQuery } from '@/hooks/queries/review/useReviewInfiniteQuery';
 import { useReviewInfiniteQuery } from '@/hooks/queries/review/useSuspenseReview';
-import { GatheringCard } from '@/types/card';
 import ParticipatingList from './gather/ParticipatingList';
+import CreatedList from './gather/CreatedList';
 
 type TabKey =
   | 'participating'
@@ -28,25 +26,7 @@ export default function MyPage() {
   ]);
 
   const [participatingCount, setParticipatingCount] = useState(0);
-
-  // 만든 모임
-  const [createdPage, setCreatedPage] = useState(0);
-  const [createdList, setCreatedList] = useState<GatheringCard[]>([]);
-  const { data: createdData, isSuccess: createdSuccess } = useGatherMeCreate({
-    page: createdPage,
-    size: 8,
-    includeCanceled: true,
-  });
-
-  useEffect(() => {
-    if (createdSuccess && createdData) {
-      setCreatedList((prev) =>
-        createdPage === 0
-          ? createdData.gatherings
-          : [...prev, ...createdData.gatherings],
-      );
-    }
-  }, [createdPage, createdData, createdSuccess]);
+  const [createdCount, setCreatedCount] = useState(0);
 
   const { data: write } = useReviewToWriteInfiniteQuery({
     size: 8,
@@ -68,19 +48,8 @@ export default function MyPage() {
       {
         key: 'created',
         label: '내가 만든 모임',
-        count: createdData?.totalElements ?? 0,
-        component: (
-          <Created
-            gatherings={createdList}
-            currentPage={createdPage}
-            totalPage={createdData?.totalPage ?? 1}
-            onLoadMore={() => {
-              if (createdPage + 1 < (createdData?.totalPage ?? 1)) {
-                setCreatedPage((prev) => prev + 1);
-              }
-            }}
-          />
-        ),
+        count: createdCount,
+        component: <CreatedList onCountChange={setCreatedCount} />,
       },
       {
         key: 'reviews_received',
@@ -95,14 +64,7 @@ export default function MyPage() {
         component: <ReviewsToWrite />,
       },
     ],
-    [
-      participatingCount,
-      createdList,
-      createdPage,
-      createdData,
-      reviewCount,
-      writeCount,
-    ],
+    [participatingCount, createdCount, reviewCount, writeCount],
   );
 
   const tabClass = (isActive: boolean) =>

--- a/src/components/products/mypage/MyPageContent.tsx
+++ b/src/components/products/mypage/MyPageContent.tsx
@@ -4,15 +4,14 @@ import clsx from 'clsx';
 import { useMemo, useEffect, useState } from 'react';
 import { useQueryTab } from '@/hooks/useQueryTab';
 import UserCard from '@/components/products/mypage/UserCard';
-import Participating from '@/components/products/mypage/gather/Participating';
 import Created from '@/components/products/mypage/gather/Created';
 import ReviewsReceived from '@/components/products/mypage/review/ReviewsReceived';
 import ReviewsToWrite from '@/components/products/mypage/towrite/ReviewsToWrite';
 import { useGatherMeCreate } from '@/hooks/queries/gather/useGatherMeCreate';
-import { useGatherMeParticipants } from '@/hooks/queries/gather/useGatherMeParticipants';
 import { useReviewToWriteInfiniteQuery } from '@/hooks/queries/review/useReviewInfiniteQuery';
 import { useReviewInfiniteQuery } from '@/hooks/queries/review/useSuspenseReview';
 import { GatheringCard } from '@/types/card';
+import ParticipatingList from './gather/ParticipatingList';
 
 type TabKey =
   | 'participating'
@@ -28,26 +27,7 @@ export default function MyPage() {
     'reviews_towrite',
   ]);
 
-  // 참가한 모임
-  const [participatingPage, setParticipatingPage] = useState(0);
-  const [participatingList, setParticipatingList] = useState<GatheringCard[]>(
-    [],
-  );
-  const { data: participatingData } = useGatherMeParticipants({
-    page: participatingPage,
-    size: 8,
-    includeCanceled: true,
-  });
-
-  useEffect(() => {
-    if (participatingData) {
-      setParticipatingList((prev) =>
-        participatingPage === 0
-          ? participatingData.gatherings
-          : [...prev, ...participatingData.gatherings],
-      );
-    }
-  }, [participatingPage, participatingData]);
+  const [participatingCount, setParticipatingCount] = useState(0);
 
   // 만든 모임
   const [createdPage, setCreatedPage] = useState(0);
@@ -82,19 +62,8 @@ export default function MyPage() {
       {
         key: 'participating',
         label: '참여 모임',
-        count: participatingData?.totalElements ?? 0,
-        component: (
-          <Participating
-            gatherings={participatingList}
-            currentPage={participatingPage}
-            totalPage={participatingData?.totalPage ?? 1}
-            onLoadMore={() => {
-              if (participatingPage + 1 < (participatingData?.totalPage ?? 1)) {
-                setParticipatingPage((prev) => prev + 1);
-              }
-            }}
-          />
-        ),
+        count: participatingCount,
+        component: <ParticipatingList onCountChange={setParticipatingCount} />,
       },
       {
         key: 'created',
@@ -127,9 +96,7 @@ export default function MyPage() {
       },
     ],
     [
-      participatingList,
-      participatingPage,
-      participatingData,
+      participatingCount,
       createdList,
       createdPage,
       createdData,

--- a/src/components/products/mypage/gather/Created.tsx
+++ b/src/components/products/mypage/gather/Created.tsx
@@ -1,44 +1,29 @@
-'use client';
-
-import { useEffect, useState } from 'react';
+import InfinityScroll from '@/components/commons/InfinityScroll';
+import CardItem from '@/components/commons/Card/CardItem';
 import { CARD_STATE } from '@/constants/card';
 import { GatheringCard } from '@/types/card';
-import InfinityScroll from '@/components/commons/InfinityScroll';
-import { GatheringsResponse } from '@/types/gather';
-import CardItem from '@/components/commons/Card/CardItem';
 
-// TODO: Recruit interface 변경이후 변경 필요
+interface CreatedProps {
+  gatherings: GatheringCard[];
+  currentPage: number;
+  totalPage: number;
+  onLoadMore: () => void;
+}
+
 export default function Created({
   gatherings,
   currentPage,
   totalPage,
-}: GatheringsResponse) {
-  const [page, setPage] = useState(currentPage);
-  const [items, setItems] = useState<GatheringCard[]>(gatherings);
-  const [hasMore, setHasMore] = useState(currentPage + 1 < totalPage);
-
-  useEffect(() => {
-    if (page !== 0) {
-      // interface교체 후 아래 코드로 반영 필요
-      // setItems((prev) => [...prev, ...data.gatherings]);
-      setItems((prev) => prev);
-      const isLastPage = currentPage + 1 >= totalPage;
-      setHasMore(!isLastPage);
-    }
-  }, [page, currentPage, totalPage]);
-
-  const handleInView = () => {
-    if (hasMore) {
-      setPage((prev) => prev + 1);
-    }
-  };
+  onLoadMore,
+}: CreatedProps) {
+  const hasMore = currentPage + 1 < totalPage;
 
   return (
     <InfinityScroll<GatheringCard>
-      list={items}
+      list={gatherings}
       item={(item) => <CardItem item={item} status={CARD_STATE.COMPLETED} />}
       emptyText="참여 중인 모집이 없습니다."
-      onInView={handleInView}
+      onInView={onLoadMore}
       hasMore={hasMore}
     />
   );

--- a/src/components/products/mypage/gather/CreatedList.tsx
+++ b/src/components/products/mypage/gather/CreatedList.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Created from '@/components/products/mypage/gather/Created';
+import { GatheringCard } from '@/types/card';
+import { useGatherMeCreate } from '@/hooks/queries/gather/useGatherMeCreate';
+
+type CreatedListProps = {
+  size?: number;
+  includeCanceled?: boolean;
+  onCountChange?: (count: number) => void;
+};
+
+export default function CreatedList({
+  size = 8,
+  includeCanceled = true,
+  onCountChange,
+}: CreatedListProps) {
+  const [page, setPage] = useState(0);
+  const [list, setList] = useState<GatheringCard[]>([]);
+
+  const { data } = useGatherMeCreate({
+    page,
+    size,
+    includeCanceled,
+  });
+
+  useEffect(() => {
+    if (data) {
+      setList((prev) =>
+        page === 0 ? data.gatherings : [...prev, ...data.gatherings],
+      );
+      if (onCountChange) {
+        onCountChange(data.totalElements);
+      }
+    }
+  }, [page, data, onCountChange]);
+
+  const loadMore = () => {
+    if (page + 1 < (data?.totalPage ?? 1)) {
+      setPage((prev) => prev + 1);
+    }
+  };
+
+  return (
+    <Created
+      gatherings={list}
+      currentPage={page}
+      totalPage={data?.totalPage ?? 1}
+      onLoadMore={loadMore}
+    />
+  );
+}

--- a/src/components/products/mypage/gather/Participating.tsx
+++ b/src/components/products/mypage/gather/Participating.tsx
@@ -1,43 +1,31 @@
 'use client';
-import { useEffect, useState } from 'react';
+
+import InfinityScroll from '@/components/commons/InfinityScroll';
+import CardItem from '@/components/commons/Card/CardItem';
 import { CARD_STATE } from '@/constants/card';
 import { GatheringCard } from '@/types/card';
-import InfinityScroll from '@/components/commons/InfinityScroll';
-import { GatheringsResponse } from '@/types/gather';
-import CardItem from '@/components/commons/Card/CardItem';
 
-// TODO: Recruit interface 변경이후 변경 필요
+interface ParticipatingProps {
+  gatherings: GatheringCard[];
+  currentPage: number;
+  totalPage: number;
+  onLoadMore: () => void;
+}
+
 export default function Participating({
   gatherings,
   currentPage,
   totalPage,
-}: GatheringsResponse) {
-  const [page, setPage] = useState(currentPage);
-  const [items, setItems] = useState<GatheringCard[]>(gatherings);
-  const [hasMore, setHasMore] = useState(currentPage + 1 < totalPage);
-
-  useEffect(() => {
-    if (page !== 0) {
-      // interface교체 후 아래 코드로 반영 필요
-      // setItems((prev) => [...prev, ...data.gatherings]);
-      setItems((prev) => prev);
-      const isLastPage = currentPage + 1 >= totalPage;
-      setHasMore(!isLastPage);
-    }
-  }, [page, currentPage, totalPage]);
-
-  const handleInView = () => {
-    if (hasMore) {
-      setPage((prev) => prev + 1);
-    }
-  };
+  onLoadMore,
+}: ParticipatingProps) {
+  const hasMore = currentPage + 1 < totalPage;
 
   return (
     <InfinityScroll<GatheringCard>
-      list={items}
+      list={gatherings}
       item={(item) => <CardItem item={item} status={CARD_STATE.COMPLETED} />}
       emptyText="참여 중인 모집이 없습니다."
-      onInView={handleInView}
+      onInView={onLoadMore}
       hasMore={hasMore}
     />
   );

--- a/src/components/products/mypage/gather/Participating.tsx
+++ b/src/components/products/mypage/gather/Participating.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import InfinityScroll from '@/components/commons/InfinityScroll';
 import CardItem from '@/components/commons/Card/CardItem';
 import { CARD_STATE } from '@/constants/card';

--- a/src/components/products/mypage/gather/ParticipatingList.tsx
+++ b/src/components/products/mypage/gather/ParticipatingList.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Participating from '@/components/products/mypage/gather/Participating';
+import { GatheringCard } from '@/types/card';
+import { useGatherMeParticipants } from '@/hooks/queries/gather/useGatherMeParticipants';
+
+type ParticipatingListProps = {
+  size?: number;
+  includeCanceled?: boolean;
+  onCountChange?: (count: number) => void;
+};
+
+export default function ParticipatingList({
+  size = 8,
+  includeCanceled = true,
+  onCountChange,
+}: ParticipatingListProps) {
+  const [page, setPage] = useState(0);
+  const [list, setList] = useState<GatheringCard[]>([]);
+
+  const { data } = useGatherMeParticipants({
+    page,
+    size,
+    includeCanceled,
+  });
+
+  useEffect(() => {
+    if (data) {
+      setList((prev) =>
+        page === 0 ? data.gatherings : [...prev, ...data.gatherings],
+      );
+      if (onCountChange) {
+        onCountChange(data.totalElements);
+      }
+    }
+  }, [page, data, onCountChange]);
+
+  const loadMore = () => {
+    if (page + 1 < (data?.totalPage ?? 1)) {
+      setPage((prev) => prev + 1);
+    }
+  };
+
+  return (
+    <Participating
+      gatherings={list}
+      currentPage={page}
+      totalPage={data?.totalPage ?? 1}
+      onLoadMore={loadMore}
+    />
+  );
+}


### PR DESCRIPTION
## 연관된 이슈

close #126 

## 작업내용
- 코드가 너무 길어져서 리스트 컴포넌트로 분리
- 무한 스크롤 적용

## 체크리스트
- 지금 csr인 상태라 쿼리탭 클릭안하면 탭 옆에 숫자가 안띄어지는 버그가 있는데, ssr + csr 하이브리드 방식 채택해서 다음 브랜치에서 반영할게요

## 스크린샷
<img width="720" alt="스크린샷 2025-06-12 오전 9 48 25" src="https://github.com/user-attachments/assets/edca85a0-d69d-4f19-a466-9e595d356081" />