### PR TITLE
[페이지] 모임 만들기 페이지 모달 적용

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,13 +9,14 @@ import {
 } from '@tanstack/react-query';
 
 interface HomeProps {
-  searchParams: {
+  searchParams: Promise<{
     showShareModal?: string;
     groupId?: string;
-  };
+  }>;
 }
 
 export default async function Home({ searchParams }: HomeProps) {
+  const resolvedSearchParams = await searchParams;
   const queryClient = new QueryClient();
   const defaultGenres: Genre[] = [];
   const defaultSessions: BandSession[] = [];
@@ -36,8 +37,8 @@ export default async function Home({ searchParams }: HomeProps) {
       <RecruitPage
         defaultGenres={defaultGenres}
         defaultSessions={defaultSessions}
-        showShareModal={searchParams.showShareModal === 'true'}
-        shareGroupId={searchParams.groupId}
+        showShareModal={resolvedSearchParams.showShareModal === 'true'}
+        shareGroupId={resolvedSearchParams.groupId}
       />
     </HydrationBoundary>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,11 +8,19 @@ import {
   QueryClient,
 } from '@tanstack/react-query';
 
-export default async function Home() {
+interface HomeProps {
+  searchParams: {
+    showShareModal?: string;
+    groupId?: string;
+  };
+}
+
+export default async function Home({ searchParams }: HomeProps) {
   const queryClient = new QueryClient();
   const defaultGenres: Genre[] = [];
   const defaultSessions: BandSession[] = [];
   const defaultSort = '';
+
   await prefetchCommonInfiniteQuery({
     queryClient,
     key: 'list',
@@ -22,11 +30,14 @@ export default async function Home() {
     includeCanceled: false,
     fetchFn: getRecruit,
   });
+
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <RecruitPage
         defaultGenres={defaultGenres}
         defaultSessions={defaultSessions}
+        showShareModal={searchParams.showShareModal === 'true'}
+        shareGroupId={searchParams.groupId}
       />
     </HydrationBoundary>
   );

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -125,10 +125,12 @@ export default function JamFormSection({
 
   const handleTagChange = useCallback(
     (selectedTags: string[]) => {
-      const convertedTags = selectedTags
-        .map((tag) => GENRE_KR_TO_ENUM[tag])
-        .filter(Boolean) as GenreType[];
-      setValue('genres', convertedTags);
+      setTimeout(() => {
+        const convertedTags = selectedTags
+          .map((tag) => GENRE_KR_TO_ENUM[tag])
+          .filter(Boolean) as GenreType[];
+        setValue('genres', convertedTags);
+      }, 0);
     },
     [setValue],
   );

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -66,7 +66,11 @@ export default function JamPage({
       });
       router.push(`/group/${groupId}`);
     } else {
-      registerGathering(data);
+      registerGathering(data, {
+        onSuccess: (response) => {
+          router.push(`/?showShareModal=true&groupId=${response.id}`);
+        },
+      });
     }
   };
 

--- a/src/components/products/recruit/RecruitPage.tsx
+++ b/src/components/products/recruit/RecruitPage.tsx
@@ -1,22 +1,30 @@
 'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import CardItem from '@/components/commons/Card/CardItem';
 import InfinityScroll from '@/components/commons/InfinityScroll';
 import RecruitHeader from '@/components/commons/RecruitHeader';
+import ShareLinkModal from '@/components/products/group/ShareLinkModal';
 import { CARD_STATE } from '@/constants/card';
 import { useCommonInfiniteQuery } from '@/hooks/queries/recruit/useRecruit';
 import { getRecruit } from '@/lib/recruit/recruit';
 import { RecruitPageProps } from '@/types/recruit';
 import { BandSession, Genre } from '@/types/tags';
-import { useState } from 'react';
 
 export default function RecruitPage({
   defaultGenres,
   defaultSessions,
+  showShareModal = false,
+  shareGroupId,
 }: RecruitPageProps) {
   // 장르, 세션
   const [genres, setGenres] = useState<Genre[]>(defaultGenres);
   const [sessions, setSessions] = useState<BandSession[]>(defaultSessions);
   const [sort, setSort] = useState<string>('');
+  const [isShareModalOpen, setIsShareModalOpen] = useState(showShareModal);
+  const router = useRouter();
+
   const { data, fetchNextPage, hasNextPage, isFetching } =
     useCommonInfiniteQuery({
       key: 'list',
@@ -29,28 +37,49 @@ export default function RecruitPage({
 
   const flatData = data?.pages.flatMap((page) => page.gatherings) ?? [];
 
+  const handleModalClose = () => {
+    setIsShareModalOpen(false);
+    const url = new URL(window.location.href);
+    url.searchParams.delete('showShareModal');
+    url.searchParams.delete('groupId');
+    router.replace(url.pathname);
+  };
+
+  useEffect(() => {
+    setIsShareModalOpen(showShareModal);
+  }, [showShareModal]);
+
   return (
-    <div className="pc:max-w-[84rem] pc:mt-8 pc:pb-[5rem] mx-auto max-w-full pb-[1.375rem]">
-      <RecruitHeader
-        genres={genres}
-        setGenres={setGenres}
-        sessions={sessions}
-        setSessions={setSessions}
-        setSort={setSort}
-      />
-      <InfinityScroll
-        list={flatData}
-        item={(item) => (
-          <CardItem item={item} isLike={true} status={CARD_STATE.PROGRESS} />
-        )}
-        emptyText=""
-        hasMore={!!hasNextPage && !isFetching}
-        onInView={() => {
-          if (hasNextPage && !isFetching) {
-            fetchNextPage();
-          }
-        }}
-      />
-    </div>
+    <>
+      <div className="pc:max-w-[84rem] pc:mt-8 pc:pb-[5rem] mx-auto max-w-full pb-[1.375rem]">
+        <RecruitHeader
+          genres={genres}
+          setGenres={setGenres}
+          sessions={sessions}
+          setSessions={setSessions}
+          setSort={setSort}
+        />
+        <InfinityScroll
+          list={flatData}
+          item={(item) => (
+            <CardItem item={item} isLike={true} status={CARD_STATE.PROGRESS} />
+          )}
+          emptyText=""
+          hasMore={!!hasNextPage && !isFetching}
+          onInView={() => {
+            if (hasNextPage && !isFetching) {
+              fetchNextPage();
+            }
+          }}
+        />
+      </div>
+
+      {isShareModalOpen && shareGroupId && (
+        <ShareLinkModal
+          inviteLink={`https://jammit-fe-six.vercel.app/group/${shareGroupId}`}
+          onClose={handleModalClose}
+        />
+      )}
+    </>
   );
 }

--- a/src/hooks/queries/gather/useGatherRegister.ts
+++ b/src/hooks/queries/gather/useGatherRegister.ts
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
 import { postRegisterGatherings } from '@/lib/gathering/register';
 import { handleAuthApiError } from '@/utils/authApiError';
@@ -8,17 +7,14 @@ import {
 } from '@/types/gather';
 
 export const useGatherRegister = () => {
-  const router = useRouter();
-
   return useMutation<
     RegisterGatheringsResponse,
     Error,
     RegisterGatheringsRequest
   >({
     mutationFn: postRegisterGatherings,
-    onSuccess: (data) => {
-      alert(`모임이 성공적으로 생성되었습니다. ID: ${data.id}`);
-      router.push(`/group/${data.id}`);
+    onSuccess: () => {
+      alert('모임이 성공적으로 생성되었습니다.');
     },
     onError: (error) => {
       handleAuthApiError(error, '모임생성에 실패했습니다.');

--- a/src/types/recruit.ts
+++ b/src/types/recruit.ts
@@ -4,6 +4,8 @@ import { BandSession, Genre } from './tags';
 export interface RecruitPageProps {
   defaultGenres: Genre[];
   defaultSessions: BandSession[];
+  showShareModal?: boolean;
+  shareGroupId?: string;
 }
 
 export interface RecruitResponse {


### PR DESCRIPTION
## 연관된 이슈

close #134 

## 작업내용
- 메이페이지 이동 후 모달 쿼리스트링 처리
- 모임 생성시 태그 비동기 처리(커밋 내용참고)
- 중복 코드 제거

## 체크리스트
- 중복코드

## 스크린샷
- 모임생성
<img width="717" alt="스크린샷 2025-06-13 오전 11 44 25" src="https://github.com/user-attachments/assets/689cab25-b8c0-4afe-a537-af489be09780" />

- 모임생성 완료
<img width="867" alt="스크린샷 2025-06-13 오전 11 44 30" src="https://github.com/user-attachments/assets/69c11ec9-e821-4798-a74f-bf6da3e17425" />

- 모임생성 완료 모달(쿼리스트링 경로)
<img width="1050" alt="스크린샷 2025-06-13 오전 11 44 37" src="https://github.com/user-attachments/assets/1d820786-12a3-4511-aaa3-b2a2d0669ad4" />

- 모달 닫으면 메인페이지로 경로
<img width="1027" alt="스크린샷 2025-06-13 오전 11 44 47" src="https://github.com/user-attachments/assets/a307359e-72d3-41c8-9a92-e4148ecaec27" />

- 모달의 주소 복사한 주소
<img width="1377" alt="스크린샷 2025-06-13 오전 11 44 57" src="https://github.com/user-attachments/assets/a900feee-5e33-4b1d-a338-f4c7ffe8cea1" />

