### PR TITLE
[리팩토링] 마이페이지, 모임생성페이지, 라이트하우스 점수향상

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -32,28 +32,6 @@ const nextConfig: NextConfig = {
     });
     return config;
   },
-
-  // gzip 압축
-  compress: true,
-  // 보안을 위해 X-Powered-By 헤더 제거
-  poweredByHeader: false,
-  headers: async () => {
-    return [
-      {
-        source: '/:path*',
-        headers: [
-          {
-            key: 'Content-Encoding',
-            value: 'gzip',
-          },
-          {
-            key: 'Vary',
-            value: 'Accept-Encoding',
-          },
-        ],
-      },
-    ];
-  },
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -32,6 +32,28 @@ const nextConfig: NextConfig = {
     });
     return config;
   },
+
+  // gzip 압축
+  compress: true,
+  // 보안을 위해 X-Powered-By 헤더 제거
+  poweredByHeader: false,
+  headers: async () => {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Encoding',
+            value: 'gzip',
+          },
+          {
+            key: 'Vary',
+            value: 'Accept-Encoding',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,30 @@ import '@/styles/globals.css';
 import Providers from './providers';
 import GlobalErrorModalProvider from '@/components/commons/Modal/GlobalErrorModalProvider';
 import Toast from '@/components/commons/Toast';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'JAMMIT - 밴드 모임 플랫폼',
+  description:
+    'JAMMIT은 밴드 모임을 위한 플랫폼입니다. 밴드원을 찾고, 모임을 만들고, 음악을 공유하세요.',
+  keywords: '밴드, 모임, 음악, 밴드원 구인, 밴드원 구직, 밴드 모임',
+  openGraph: {
+    title: 'JAMMIT - 밴드 모임 플랫폼',
+    description:
+      'JAMMIT은 밴드 모임을 위한 플랫폼입니다. 밴드원을 찾고, 모임을 만들고, 음악을 공유하세요.',
+    type: 'website',
+    locale: 'ko_KR',
+    siteName: 'JAMMIT',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'JAMMIT - 밴드 모임 플랫폼',
+    description:
+      'JAMMIT은 밴드 모임을 위한 플랫폼입니다. 밴드원을 찾고, 모임을 만들고, 음악을 공유하세요.',
+  },
+  viewport: 'width=device-width, initial-scale=1',
+  robots: 'index, follow',
+};
 
 export default function RootLayout({
   children,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,13 @@ import {
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'JAMMIT - 밴드 모임 플랫폼 | 홈',
+  description:
+    'JAMMIT에서 밴드원을 찾고, 모임을 만들고, 음악을 공유하세요. 다양한 밴드 모임을 둘러보고 참여해보세요.',
+};
 
 interface HomeProps {
   searchParams: Promise<{

--- a/src/components/commons/Card/TitleBlock.tsx
+++ b/src/components/commons/Card/TitleBlock.tsx
@@ -11,9 +11,7 @@ export default function TitleBlock({ title, author }: TitleBlockProps) {
       <div className="mt-5 truncate text-lg leading-none font-semibold">
         {title}
       </div>
-      <div className="mt-5 leading-none text-[color:var(--gray-50)]">
-        {author}
-      </div>
+      <div className="mt-5 leading-none text-gray-300">{author}</div>
     </>
   );
 }

--- a/src/components/commons/Gnb.tsx
+++ b/src/components/commons/Gnb.tsx
@@ -41,7 +41,11 @@ export default function Gnb() {
       <div className="flex h-[3.75rem] w-full items-center justify-center bg-[#151515] px-[1.75rem]">
         <div className="flex w-full max-w-[84rem] items-center justify-between text-white">
           <nav className="flex gap-[1.5rem]">
-            <Link href="/" data-active={pathname === '/'}>
+            <Link
+              href="/"
+              data-active={pathname === '/'}
+              aria-label="JAMMIT 홈으로 이동"
+            >
               <JammitLogo />
             </Link>
             {navItems.map(({ href, label }) => (
@@ -50,6 +54,7 @@ export default function Gnb() {
                 href={href}
                 data-active={pathname === href}
                 className="font-semibold text-gray-300 data-[active=true]:font-bold data-[active=true]:text-gray-100"
+                aria-label={`${label} 페이지로 이동`}
               >
                 {label}
               </Link>
@@ -68,6 +73,7 @@ export default function Gnb() {
                 data-active={pathname === '/login'}
                 className="font-semibold opacity-80 data-[active=true]:font-bold data-[active=true]:opacity-100"
                 href="/login"
+                aria-label="로그인 페이지로 이동"
               >
                 로그인
               </Link>

--- a/src/components/products/jam/DateFormSection.tsx
+++ b/src/components/products/jam/DateFormSection.tsx
@@ -1,0 +1,51 @@
+import { Control, Controller } from 'react-hook-form';
+import { DatePicker } from '@/components/commons/DatePicker/DatePicker';
+import { RegisterGatheringsRequest } from '@/types/gather';
+import { formatDateToLocal } from '@/utils/formatDateToLocal';
+
+const DATE_FIELDS = [
+  {
+    name: 'recruitDateTime' as const,
+    label: '모집 마감일',
+    htmlFor: 'end',
+  },
+  {
+    name: 'gatheringDateTime' as const,
+    label: '모임 날짜',
+    htmlFor: 'day',
+  },
+] as const;
+
+interface DateFormSectionProps {
+  control: Control<RegisterGatheringsRequest>;
+}
+
+export default function DateFormSection({ control }: DateFormSectionProps) {
+  return (
+    <div className="flex gap-[1.25rem]">
+      {DATE_FIELDS.map(({ name, label, htmlFor }) => (
+        <div key={name} className="flex flex-col gap-[0.5rem]">
+          <label htmlFor={htmlFor} className="font-semibold">
+            {label}
+          </label>
+          <Controller
+            name={name}
+            control={control}
+            rules={{ required: `${label}을 선택하세요.` }}
+            render={({ field }) => (
+              <DatePicker
+                value={field.value ? new Date(field.value) : undefined}
+                onChange={(date) => {
+                  if (!date) {
+                    return field.onChange('');
+                  }
+                  field.onChange(formatDateToLocal(date));
+                }}
+              />
+            )}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/products/jam/DescriptionFormSection.tsx
+++ b/src/components/products/jam/DescriptionFormSection.tsx
@@ -1,0 +1,29 @@
+import { Control, Controller } from 'react-hook-form';
+import TextArea from '@/components/commons/Textarea';
+import { RegisterGatheringsRequest } from '@/types/gather';
+
+interface DescriptionFormSectionProps {
+  control: Control<RegisterGatheringsRequest>;
+}
+
+export default function DescriptionFormSection({
+  control,
+}: DescriptionFormSectionProps) {
+  return (
+    <div className="flex flex-col gap-[0.5rem]">
+      <p className="text-lg font-semibold">소개글</p>
+      <Controller
+        name="description"
+        control={control}
+        rules={{ required: '소개글을 입력하세요.' }}
+        render={({ field }) => (
+          <TextArea
+            placeholder="어떤 일이 일어날까요?"
+            value={field.value}
+            onChange={field.onChange}
+          />
+        )}
+      />
+    </div>
+  );
+}

--- a/src/components/products/jam/GenreFormSection.tsx
+++ b/src/components/products/jam/GenreFormSection.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useRef } from 'react';
+import { UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import TagSelector from '@/components/commons/TagSelector';
+import { GENRE_TAGS } from '@/constants/tags';
+import { GENRE_KR_TO_ENUM } from '@/constants/tagsMapping';
+import { RegisterGatheringsRequest } from '@/types/gather';
+import { GenreType } from '@/types/tags';
+
+interface GenreFormSectionProps {
+  setValue: UseFormSetValue<RegisterGatheringsRequest>;
+  watch: UseFormWatch<RegisterGatheringsRequest>;
+}
+
+export default function GenreFormSection({
+  setValue,
+  watch,
+}: GenreFormSectionProps) {
+  const pendingUpdateRef = useRef<string[] | null>(null);
+
+  const handleTagChange = useCallback(
+    (tags: string[]) => {
+      pendingUpdateRef.current = tags;
+      requestAnimationFrame(() => {
+        if (pendingUpdateRef.current) {
+          const convertedTags = pendingUpdateRef.current
+            .map((tag) => GENRE_KR_TO_ENUM[tag])
+            .filter(Boolean) as GenreType[];
+          setValue('genres', convertedTags);
+          pendingUpdateRef.current = null;
+        }
+      });
+    },
+    [setValue],
+  );
+
+  return (
+    <div className="flex flex-col gap-[0.5rem]">
+      <p className="text-lg font-semibold">모임 장르</p>
+      <TagSelector
+        mode="selectable"
+        tags={GENRE_TAGS}
+        onChange={handleTagChange}
+        initialSelected={(watch('genres') || []).map(
+          (enumVal) =>
+            Object.keys(GENRE_KR_TO_ENUM).find(
+              (k) => GENRE_KR_TO_ENUM[k] === enumVal,
+            ) || '',
+        )}
+      />
+    </div>
+  );
+}

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -1,49 +1,21 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import {
-  Control,
-  UseFormWatch,
-  UseFormSetValue,
-  Controller,
-} from 'react-hook-form';
+import { useCallback } from 'react';
+import { Control, UseFormWatch, UseFormSetValue } from 'react-hook-form';
 import Input from '@/components/commons/Input';
-import TextArea from '@/components/commons/Textarea';
-import TagSelector from '@/components/commons/TagSelector';
-import Button from '@/components/commons/Button';
-import { DatePicker } from '@/components/commons/DatePicker/DatePicker';
 import SearchInput from './SearchInput';
-import SessionSelector from './SessionSelector';
-import { GENRE_TAGS, SESSION_KEY_MAP } from '@/constants/tags';
-import { GENRE_KR_TO_ENUM, SESSION_ENUM_TO_KR } from '@/constants/tagsMapping';
 import { RegisterGatheringsRequest } from '@/types/gather';
-import { GenreType } from '@/types/tags';
-import { formatDateToLocal } from '@/utils/formatDateToLocal';
-import { useWatch } from 'react-hook-form';
+import SessionFormSection from './SessionFormSection';
+import DateFormSection from './DateFormSection';
+import GenreFormSection from './GenreFormSection';
+import DescriptionFormSection from './DescriptionFormSection';
 
 const DIVIDER = 'mx-auto my-[2.5rem] w-[56rem] border-gray-800';
 
-const DATE_FIELDS = [
-  {
-    name: 'recruitDateTime' as const,
-    label: '모집 마감일',
-    htmlFor: 'end',
-  },
-  {
-    name: 'gatheringDateTime' as const,
-    label: '모임 날짜',
-    htmlFor: 'day',
-  },
-] as const;
-
 interface JamFormSectionProps {
-  /** 폼 필드 제어 */
   control: Control<RegisterGatheringsRequest>;
-  /** 필드 값 관찰 */
   watch: UseFormWatch<RegisterGatheringsRequest>;
-  /** 필드 값을 외부에서 설정 */
   setValue: UseFormSetValue<RegisterGatheringsRequest>;
-  /** 초기값 */
   initialData?: RegisterGatheringsRequest;
 }
 
@@ -53,100 +25,14 @@ export default function JamFormSection({
   setValue,
   initialData,
 }: JamFormSectionProps) {
-  const [sessionList, setSessionList] = useState(() => {
-    if (initialData?.gatheringSessions?.length) {
-      return initialData.gatheringSessions.map((s) => ({
-        sortOption: SESSION_ENUM_TO_KR[s.bandSession] || '',
-        count: s.recruitCount,
-      }));
-    }
-    return [{ sortOption: '', count: 0 }];
-  });
-
   const place = watch('place') || '';
 
-  // 빈 문자열 제외 이미 선택된 세션 옵션들을 계산
-  const selectedSessions = sessionList
-    .map((session) => session.sortOption)
-    .filter((option) => option !== '');
-
-  // 장소 선택
   const handlePlaceChange = useCallback(
     (val: string) => {
       setValue('place', val);
     },
     [setValue],
   );
-
-  // 세션 추가
-  const handleAddSession = useCallback(() => {
-    setSessionList((prev) => [...prev, { sortOption: '', count: 0 }]);
-  }, []);
-
-  // 세션 삭제
-  const handleDeleteSession = useCallback((index: number) => {
-    setSessionList((prev) => prev.filter((_, i) => i !== index));
-  }, []);
-
-  // 세션 드롭다운 변경
-  const handleSortOptionChange = useCallback(
-    (index: number, newSortOption: string) => {
-      setSessionList((prev) =>
-        prev.map((session, idx) =>
-          idx === index ? { ...session, sortOption: newSortOption } : session,
-        ),
-      );
-    },
-    [],
-  );
-
-  // 세션 드롭다운 인원 변경
-  const handleCountChange = useCallback(
-    (index: number, newCount: number) => {
-      setSessionList((prev) => {
-        const newList = prev.map((session, i) =>
-          i === index ? { ...session, count: newCount } : session,
-        );
-
-        setValue(
-          `gatheringSessions`,
-          newList
-            .filter((s) => s.sortOption !== '')
-            .map((s) => ({
-              bandSession: SESSION_KEY_MAP[s.sortOption],
-              recruitCount: s.count,
-            })),
-        );
-        return newList;
-      });
-    },
-    [setValue],
-  );
-
-  const handleTagChange = useCallback(
-    (selectedTags: string[]) => {
-      setTimeout(() => {
-        const convertedTags = selectedTags
-          .map((tag) => GENRE_KR_TO_ENUM[tag])
-          .filter(Boolean) as GenreType[];
-        setValue('genres', convertedTags);
-      }, 0);
-    },
-    [setValue],
-  );
-
-  const gatheringSessions = useWatch({ name: 'gatheringSessions', control });
-
-  useEffect(() => {
-    if (gatheringSessions?.length) {
-      setSessionList(
-        gatheringSessions.map((s) => ({
-          sortOption: SESSION_ENUM_TO_KR[s.bandSession],
-          count: s.recruitCount,
-        })),
-      );
-    }
-  }, [gatheringSessions]);
 
   return (
     <div className="mt-[2.5rem] flex h-auto w-[61rem] flex-col bg-[#202024] p-[2.5rem]">
@@ -170,104 +56,27 @@ export default function JamFormSection({
         <SearchInput value={place} onChange={handlePlaceChange} />
 
         {/** 모집 마감일 / 모임 날짜 */}
-        <div className="flex gap-[1.25rem]">
-          {DATE_FIELDS.map(({ name, label, htmlFor }) => (
-            <div key={name} className="flex flex-col gap-[0.5rem]">
-              <label htmlFor={htmlFor} className="font-semibold">
-                {label}
-              </label>
-              <Controller
-                name={name}
-                control={control}
-                rules={{ required: `${label}을 선택하세요.` }}
-                render={({ field }) => (
-                  <DatePicker
-                    value={field.value ? new Date(field.value) : undefined}
-                    onChange={(date) => {
-                      if (!date) {
-                        return field.onChange('');
-                      }
-                      field.onChange(formatDateToLocal(date));
-                    }}
-                  />
-                )}
-              />
-            </div>
-          ))}
-        </div>
+        <DateFormSection control={control} />
       </div>
 
       <hr className={DIVIDER} />
 
       {/** 모집 세션 */}
-      <div className="flex flex-col gap-[0.5rem]">
-        <p className="text-lg font-semibold">모집 세션</p>
-        <div className="flex flex-row justify-between">
-          <div className="flex flex-col gap-[0.75rem]">
-            {sessionList.map(({ sortOption, count }, index) => (
-              <SessionSelector
-                key={index}
-                session={{ [SESSION_KEY_MAP[sortOption]]: count }}
-                sortOption={sortOption}
-                setSortOption={(val) => handleSortOptionChange(index, val)}
-                onChange={(val) => handleCountChange(index, val)}
-                selectedOptions={selectedSessions}
-              />
-            ))}
-          </div>
-          <div className="flex gap-[0.75rem]">
-            <Button variant="outline" size="small" onClick={handleAddSession}>
-              추가
-            </Button>
+      <SessionFormSection
+        control={control}
+        setValue={setValue}
+        initialData={initialData}
+      />
 
-            <Button
-              variant="outline"
-              size="small"
-              onClick={() => handleDeleteSession(sessionList.length - 1)}
-              disabled={sessionList.length === 1}
-            >
-              삭제
-            </Button>
-          </div>
-        </div>
+      <hr className={DIVIDER} />
 
-        <hr className={DIVIDER} />
+      {/* 모임 장르 */}
+      <GenreFormSection watch={watch} setValue={setValue} />
 
-        {/* 모임 장르 */}
-        <div className="flex flex-col gap-[0.5rem]">
-          <p className="text-lg font-semibold">모임 장르</p>
-          <TagSelector
-            mode="selectable"
-            tags={GENRE_TAGS}
-            onChange={handleTagChange}
-            initialSelected={(watch('genres') || []).map(
-              (enumVal) =>
-                Object.keys(GENRE_KR_TO_ENUM).find(
-                  (k) => GENRE_KR_TO_ENUM[k] === enumVal,
-                ) || '',
-            )}
-          />
-        </div>
+      <hr className={DIVIDER} />
 
-        <hr className={DIVIDER} />
-
-        {/* 소개글 */}
-        <div className="flex flex-col gap-[0.5rem]">
-          <p className="text-lg font-semibold">소개글</p>
-          <Controller
-            name="description"
-            control={control}
-            rules={{ required: '소개글을 입력하세요.' }}
-            render={({ field }) => (
-              <TextArea
-                placeholder="어떤 일이 일어날까요?"
-                value={field.value}
-                onChange={field.onChange}
-              />
-            )}
-          />
-        </div>
-      </div>
+      {/* 소개글 */}
+      <DescriptionFormSection control={control} />
     </div>
   );
 }

--- a/src/components/products/jam/SessionFormSection.tsx
+++ b/src/components/products/jam/SessionFormSection.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useState, useEffect } from 'react';
+import { Control, UseFormSetValue, useWatch } from 'react-hook-form';
+import Button from '@/components/commons/Button';
+import SessionSelector from './SessionSelector';
+import { SESSION_KEY_MAP } from '@/constants/tags';
+import { SESSION_ENUM_TO_KR } from '@/constants/tagsMapping';
+import { RegisterGatheringsRequest } from '@/types/gather';
+
+interface SessionFormSectionProps {
+  control: Control<RegisterGatheringsRequest>;
+  setValue: UseFormSetValue<RegisterGatheringsRequest>;
+  initialData?: RegisterGatheringsRequest;
+}
+
+export default function SessionFormSection({
+  control,
+  setValue,
+  initialData,
+}: SessionFormSectionProps) {
+  const [sessionList, setSessionList] = useState(() => {
+    if (initialData?.gatheringSessions?.length) {
+      return initialData.gatheringSessions.map((s) => ({
+        sortOption: SESSION_ENUM_TO_KR[s.bandSession] || '',
+        count: s.recruitCount,
+      }));
+    }
+    return [{ sortOption: '', count: 0 }];
+  });
+
+  const selectedSessions = sessionList
+    .map((session) => session.sortOption)
+    .filter((option) => option !== '');
+
+  const handleAddSession = useCallback(() => {
+    setSessionList((prev) => [...prev, { sortOption: '', count: 0 }]);
+  }, []);
+
+  const handleDeleteSession = useCallback((index: number) => {
+    setSessionList((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleSortOptionChange = useCallback(
+    (index: number, newSortOption: string) => {
+      setSessionList((prev) =>
+        prev.map((session, idx) =>
+          idx === index ? { ...session, sortOption: newSortOption } : session,
+        ),
+      );
+    },
+    [],
+  );
+
+  const handleCountChange = useCallback(
+    (index: number, newCount: number) => {
+      setSessionList((prev) => {
+        const newList = prev.map((session, i) =>
+          i === index ? { ...session, count: newCount } : session,
+        );
+
+        setValue(
+          `gatheringSessions`,
+          newList
+            .filter((s) => s.sortOption !== '')
+            .map((s) => ({
+              bandSession: SESSION_KEY_MAP[s.sortOption],
+              recruitCount: s.count,
+            })),
+        );
+        return newList;
+      });
+    },
+    [setValue],
+  );
+
+  const gatheringSessions = useWatch({ name: 'gatheringSessions', control });
+
+  useEffect(() => {
+    if (gatheringSessions?.length) {
+      setSessionList(
+        gatheringSessions.map((s) => ({
+          sortOption: SESSION_ENUM_TO_KR[s.bandSession],
+          count: s.recruitCount,
+        })),
+      );
+    }
+  }, [gatheringSessions]);
+
+  return (
+    <div className="flex flex-col gap-[0.5rem]">
+      <p className="text-lg font-semibold">모집 세션</p>
+      <div className="flex flex-row justify-between">
+        <div className="flex flex-col gap-[0.75rem]">
+          {sessionList.map(({ sortOption, count }, index) => (
+            <SessionSelector
+              key={index}
+              session={
+                sortOption ? { [SESSION_KEY_MAP[sortOption]]: count } : {}
+              }
+              sortOption={sortOption}
+              setSortOption={(val) => handleSortOptionChange(index, val)}
+              onChange={(val) => handleCountChange(index, val)}
+              selectedOptions={selectedSessions}
+            />
+          ))}
+        </div>
+        <div className="flex gap-[0.75rem]">
+          <Button variant="outline" size="small" onClick={handleAddSession}>
+            추가
+          </Button>
+          <Button
+            variant="outline"
+            size="small"
+            onClick={() => handleDeleteSession(sessionList.length - 1)}
+            disabled={sessionList.length === 1}
+          >
+            삭제
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/products/mypage/UserCard.tsx
+++ b/src/components/products/mypage/UserCard.tsx
@@ -80,7 +80,11 @@ export default function UserCard() {
             <p className="text-[1.5rem] leading-[2.4rem] font-bold">
               {displayUser.username}
             </p>
-            <button type="submit" onClick={handleProfileEdit}>
+            <button
+              type="submit"
+              onClick={handleProfileEdit}
+              aria-label="수정 버튼"
+            >
               <EditIcon width={18} height={18} />
             </button>
           </div>

--- a/src/hooks/queries/gather/useGatherMeCreate.ts
+++ b/src/hooks/queries/gather/useGatherMeCreate.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import { GetUserGatheringsParams } from '@/types/gather';
@@ -30,22 +30,20 @@ export function useCreatedCount() {
   const [createdCount, setCreatedCount] = useState(0);
   const queryClient = useQueryClient();
 
-  useEffect(() => {
-    const { queryKey, queryFn } = gatherMeCreateQuery({
-      page: 0,
-      size: 1,
-      includeCanceled: true,
-    });
+  const { queryKey, queryFn } = gatherMeCreateQuery({
+    page: 0,
+    size: 1,
+    includeCanceled: true,
+  });
 
-    queryClient.prefetchQuery({ queryKey, queryFn }).then(() => {
-      const cachedData = queryClient.getQueryData<{ totalElements: number }>(
-        queryKey,
-      );
-      if (cachedData && typeof cachedData.totalElements === 'number') {
-        setCreatedCount(cachedData.totalElements);
-      }
-    });
-  }, [queryClient]);
+  queryClient.prefetchQuery({ queryKey, queryFn }).then(() => {
+    const cachedData = queryClient.getQueryData<{ totalElements: number }>(
+      queryKey,
+    );
+    if (cachedData && typeof cachedData.totalElements === 'number') {
+      setCreatedCount(cachedData.totalElements);
+    }
+  });
 
   return createdCount;
 }

--- a/src/hooks/queries/gather/useGatherMeCreate.ts
+++ b/src/hooks/queries/gather/useGatherMeCreate.ts
@@ -24,6 +24,11 @@ export const useGatherMeCreate = (
     queryKey: ['me', 'created', page, size, includeCanceled],
     queryFn: () => getUserCreatedGatherings({ page, size, includeCanceled }),
     retry: true,
+    staleTime: 5 * 60 * 1000, // 5분
+    cacheTime: 10 * 60 * 1000, // 10분
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
   });
 
 export function useCreatedCount() {

--- a/src/hooks/queries/gather/useGatherMeCreate.ts
+++ b/src/hooks/queries/gather/useGatherMeCreate.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import { GetUserGatheringsParams } from '@/types/gather';
@@ -36,14 +36,16 @@ export function useCreatedCount() {
     includeCanceled: true,
   });
 
-  queryClient.prefetchQuery({ queryKey, queryFn }).then(() => {
-    const cachedData = queryClient.getQueryData<{ totalElements: number }>(
-      queryKey,
-    );
-    if (cachedData && typeof cachedData.totalElements === 'number') {
-      setCreatedCount(cachedData.totalElements);
-    }
-  });
+  useEffect(() => {
+    queryClient.prefetchQuery({ queryKey, queryFn }).then(() => {
+      const cachedData = queryClient.getQueryData<{ totalElements: number }>(
+        queryKey,
+      );
+      if (cachedData && typeof cachedData.totalElements === 'number') {
+        setCreatedCount(cachedData.totalElements);
+      }
+    });
+  }, [queryClient, queryKey, queryFn]);
 
   return createdCount;
 }

--- a/src/hooks/queries/gather/useGatherMeCreate.ts
+++ b/src/hooks/queries/gather/useGatherMeCreate.ts
@@ -16,7 +16,7 @@ export const gatherMeCreateQuery = ({
 export const useGatherMeCreate = (
   { page, size, includeCanceled = false }: GetUserGatheringsParams = {
     page: 0,
-    size: 8,
+    size: 4,
     includeCanceled: true,
   },
 ) =>
@@ -24,8 +24,8 @@ export const useGatherMeCreate = (
     queryKey: ['me', 'created', page, size, includeCanceled],
     queryFn: () => getUserCreatedGatherings({ page, size, includeCanceled }),
     retry: true,
-    staleTime: 5 * 60 * 1000, // 5분
-    cacheTime: 10 * 60 * 1000, // 10분
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnMount: false,
     refetchOnReconnect: false,

--- a/src/hooks/queries/gather/useGatherMeParticipants.ts
+++ b/src/hooks/queries/gather/useGatherMeParticipants.ts
@@ -3,9 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 import { GetUserGatheringsParams } from '@/types/gather';
 
 export const useGatherMeParticipants = (
-  { page, size, includeCanceled = false }: GetUserGatheringsParams = {
+  { page, size = 4, includeCanceled = false }: GetUserGatheringsParams = {
     page: 0,
-    size: 8,
+    size: 4,
     includeCanceled: true,
   },
 ) =>
@@ -14,4 +14,6 @@ export const useGatherMeParticipants = (
     queryFn: () =>
       getUserParticipantsGatherings({ page, size, includeCanceled }),
     retry: true,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
   });

--- a/src/hooks/queries/gather/useGatherModify.ts
+++ b/src/hooks/queries/gather/useGatherModify.ts
@@ -1,13 +1,14 @@
 import { putModifiedGatherings } from '@/lib/gathering/modified';
 import { handleAuthApiError } from '@/utils/authApiError';
 import { useMutation } from '@tanstack/react-query';
+import { useToastStore } from '@/stores/useToastStore';
 
 export const useGatherModify = () =>
   useMutation({
     mutationFn: putModifiedGatherings,
 
     onSuccess: () => {
-      alert('모임 수정 완료되었습니다.');
+      useToastStore.getState().show('모임 수정 완료되었습니다.');
     },
 
     onError: (error) => handleAuthApiError(error, '모임 수정에 실패했습니다.'),

--- a/src/hooks/queries/gather/useGatherRegister.ts
+++ b/src/hooks/queries/gather/useGatherRegister.ts
@@ -5,6 +5,7 @@ import {
   RegisterGatheringsRequest,
   RegisterGatheringsResponse,
 } from '@/types/gather';
+import { useToastStore } from '@/stores/useToastStore';
 
 export const useGatherRegister = () => {
   return useMutation<
@@ -14,7 +15,7 @@ export const useGatherRegister = () => {
   >({
     mutationFn: postRegisterGatherings,
     onSuccess: () => {
-      alert('모임이 성공적으로 생성되었습니다.');
+      useToastStore.getState().show('모임이 성공적으로 생성되었습니다.');
     },
     onError: (error) => {
       handleAuthApiError(error, '모임생성에 실패했습니다.');

--- a/src/hooks/useQueryTab.tsx
+++ b/src/hooks/useQueryTab.tsx
@@ -1,4 +1,9 @@
 'use client';
+
+/**
+ * useQueryTab hook은 브라우저 환경(클라이언트 사이드)에서만 동작
+ * SSR 환경에서는 document가 없기 때문에 사용 시 주의하세요.
+ */
 import { useRouter, useSearchParams } from 'next/navigation';
 
 export function useQueryTab<T extends string>(

--- a/src/lib/react-query.ts
+++ b/src/lib/react-query.ts
@@ -25,6 +25,11 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 0,
+      staleTime: 5 * 60 * 1000, // 5분
+      cacheTime: 10 * 60 * 1000, // 10분
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
     },
   },
 });

--- a/src/lib/react-query.ts
+++ b/src/lib/react-query.ts
@@ -25,8 +25,8 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 0,
-      staleTime: 5 * 60 * 1000, // 5분
-      cacheTime: 10 * 60 * 1000, // 10분
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,14 +6,14 @@
   --background: #1a1a1e;
   --foreground: #f3f4f6;
   --primary: #c179ff;
-  --purple-500:#BF5eff;
-  --purple-700:#9900ff;
+  --purple-500: #BF5eff;
+  --purple-700: #9900ff;
   --bg-34343A: #34343a;
   --gray-50: #68696c;
-  --gray-100:#29292C;
-  --gray-400:#9CA3AF;
-  --gray-500:#6b7280;
-  --gray-600:#4b5563;
+  --gray-100: #29292C;
+  --gray-400: #9CA3AF;
+  --gray-500: #6b7280;
+  --gray-600: #4b5563;
 }
 
 @theme {
@@ -40,9 +40,11 @@
       'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji',
       'Segoe UI Symbol', sans-serif;
   }
+
   body {
     font-family: var(--font-pretendard);
   }
+
   html,
   body {
     margin: 0;
@@ -59,19 +61,23 @@
   *::after {
     box-sizing: border-box;
   }
+
   button {
     all: unset;
     cursor: pointer;
     box-sizing: border-box;
     transition: background-color 0.2s ease;
   }
+
   p {
     margin: 0;
   }
+
   button:disabled {
     cursor: not-allowed;
     opacity: 0.5;
   }
+
   em {
     font-style: normal;
   }
@@ -122,7 +128,7 @@
     -webkit-box-shadow: 0 0 0 1000px #34343a inset;
     -webkit-text-fill-color: white;
   }
- 
+
 }
 
 ::-webkit-scrollbar {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,9 +9,9 @@
   --purple-500: #BF5eff;
   --purple-700: #9900ff;
   --bg-34343A: #34343a;
-  --gray-50: #68696c;
+  --gray-50: #9CA3AF;
   --gray-100: #29292C;
-  --gray-400: #9CA3AF;
+  --gray-400: #D1D5DB;
   --gray-500: #6b7280;
   --gray-600: #4b5563;
 }
@@ -27,7 +27,9 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
-    --foreground: #ededed;
+    --foreground: #f3f4f6;
+    --gray-50: #9CA3AF;
+    --gray-400: #D1D5DB;
   }
 }
 

--- a/src/utils/authApiError.ts
+++ b/src/utils/authApiError.ts
@@ -1,8 +1,9 @@
+import { useToastStore } from '@/stores/useToastStore';
+
 export const handleAuthApiError = (error: unknown, fallbackMessage: string) => {
   if (error instanceof Error) {
-    // TODO: 모달, 토스트 등 적용 필요
-    alert(error.message);
+    useToastStore.getState().show(error.message);
   } else {
-    alert(fallbackMessage);
+    useToastStore.getState().show(fallbackMessage);
   }
 };


### PR DESCRIPTION
## 연관된 이슈

close #137

## 작업내용
- 모임 생성/수정 폼 컴포넌트 분리
- prefetch에서 useEffect 사용안하려했지만 마운트 오류로 결국 사용
- 메타데이터, 로고에 aria-label등 추가해서 라이트하우스 점수 향상
- alert -> toast로 변경

## 체크리스트
- 성능은 각 페이지 담당자가 하는게 맞을 거 같기도하고 브랜치 크기 커질것 같아서 브랜치 또 파서 할게요
- @euoonw @jinhwansong 접근성 향상같은 경우에는 색상 대비에서 문제가 나오는데, 디자이너분이 정하신거라 저희가 맘대로 변경해도될지 모르겠어서 변경은 안했어요. 근데 변경했을때는 점수가 100점으로 나오긴 하네요. 아래는 변경해야될 색상이에요. 저는 올리는 방향이 좋을 것 같아서 저희끼리 그냥 수정해도 좋을 것 같아요. 만약 다들 동의하시면 수정하고 머지할게요. 의견남겨주세요
```ts
 --gray-50: #9CA3AF;
 --gray-400:#D1D5DB;
 
@media (prefers-color-scheme: dark) {
  :root {
    --background: #0a0a0a;
    --foreground: #f3f4f6;
    --gray-50: #9CA3AF;
    --gray-400: #D1D5DB;
  }
}
```

## 스크린샷
<img width="453" alt="스크린샷 2025-06-14 오후 4 42 56" src="https://github.com/user-attachments/assets/3eff2396-3e16-474e-a984-a11cb9ec306f" />
