### PR TITLE
[기능] 리뷰 작성 완료한 참여자 리뷰작성 버튼 비활성화

### DIFF
--- a/src/components/commons/Modal/ErrorModal.tsx
+++ b/src/components/commons/Modal/ErrorModal.tsx
@@ -11,8 +11,13 @@ interface ErrorModalProps {
 export default function ErrorModal({ message, onClose }: ErrorModalProps) {
   const router = useRouter();
 
+  const loginErrorMessages = [
+    '로그인이 필요한 서비스입니다.',
+    '세션이 만료되었습니다. 다시 로그인 해주세요.',
+  ];
+
   const handleConfirm = () => {
-    if (message === '로그인이 필요한 서비스입니다.') {
+    if (loginErrorMessages.includes(message)) {
       router.push('/login');
     }
     onClose();

--- a/src/components/products/group/GroupInfoSection.tsx
+++ b/src/components/products/group/GroupInfoSection.tsx
@@ -37,9 +37,7 @@ export default function GroupInfoSection({
     id,
   } = gathering;
 
-  const isCanceled = status === 'CANCELED';
-  const isHostAndActive = isHost && !isCanceled;
-  const isCompleted = status === 'COMPLETED';
+  const isRecruiting = status == 'RECRUITING';
 
   const deleteMutation = useDeleteGatheringMutation();
 
@@ -149,7 +147,7 @@ export default function GroupInfoSection({
       </section>
 
       <div className="ml-[1.25rem]">
-        {!isCompleted && isHostAndActive && (
+        {isRecruiting && isHost && (
           <div className="flex flex-col gap-[1.25rem]">
             {actionButtons.map(({ label, variant, onClick }) => (
               <Button

--- a/src/components/products/group/GroupPage.tsx
+++ b/src/components/products/group/GroupPage.tsx
@@ -27,12 +27,17 @@ export default function GroupPage() {
     'recruit',
     'members',
   ]);
-  const user = useUserStore((state) => state.user);
+  const { user, isLoaded, isRefreshing } = useUserStore();
+  const isQueryReady = isLoaded && !isRefreshing && !!user;
+
   const { groupId } = useParams();
   const numericId = Number(groupId);
   const [showParticipationForm, setShowParticipationForm] = useState(false);
 
   useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
     if (activeTab === 'members' && !user) {
       alert('로그인 후 이용 가능한 기능입니다.');
       router.push('/login');
@@ -53,7 +58,7 @@ export default function GroupPage() {
     isLoading: isParticipantsLoading,
     error: participantsError,
   } = useGatheringParticipantsQuery(numericId, {
-    enabled: !!user,
+    enabled: isQueryReady,
   });
 
   const participateMutation = useParticipateGatheringMutation();

--- a/src/components/products/group/GroupPage.tsx
+++ b/src/components/products/group/GroupPage.tsx
@@ -108,6 +108,7 @@ export default function GroupPage() {
   const isMyParticipantApproved = myParticipantStatus === 'APPROVED';
   const isMyParticipantRejected = myParticipantStatus === 'REJECTED';
   const myParticipantId = myParticipant?.participantId;
+  console.log('my status: ', myParticipantStatus);
 
   const approvedParticipants = participants.filter(
     (participant) => participant.status === 'APPROVED',
@@ -164,7 +165,8 @@ export default function GroupPage() {
     | 'RECRUITING_HOST'
     | 'RECRUITING_PARTICIPATING'
     | 'RECRUITING_FORM'
-    | 'RECRUITING_JOIN';
+    | 'RECRUITING_JOIN'
+    | 'RECRUITING_REJECTED';
 
   let buttonState: ButtonState;
 
@@ -185,6 +187,8 @@ export default function GroupPage() {
   } else if (isRecruiting) {
     if (isHost) {
       buttonState = 'RECRUITING_HOST';
+    } else if (isMyParticipantRejected) {
+      buttonState = 'RECRUITING_REJECTED';
     } else if (isParticipating) {
       buttonState = 'RECRUITING_PARTICIPATING';
     } else if (showParticipationForm) {
@@ -245,6 +249,12 @@ export default function GroupPage() {
               참여 취소
             </button>
           </div>
+        );
+      case 'RECRUITING_REJECTED':
+        return (
+          <Button disabled className="w-[22.75rem]">
+            신청 거절된 모임입니다
+          </Button>
         );
       case 'RECRUITING_FORM':
         return (

--- a/src/components/products/group/GroupPage.tsx
+++ b/src/components/products/group/GroupPage.tsx
@@ -139,62 +139,88 @@ export default function GroupPage() {
     setShowParticipationForm(false);
   };
 
+  type ButtonState =
+    | 'CANCELED'
+    | 'COMPLETED'
+    | 'CONFIRMED_REJECTED'
+    | 'CONFIRMED_APPROVED'
+    | 'CONFIRMED_HOST'
+    | 'CONFIRMED_DEFAULT'
+    | 'RECRUITING_HOST'
+    | 'RECRUITING_PARTICIPATING'
+    | 'RECRUITING_FORM'
+    | 'RECRUITING_JOIN';
+
+  let buttonState: ButtonState;
+
+  if (isCanceled) {
+    buttonState = 'CANCELED';
+  } else if (isCompleted) {
+    buttonState = 'COMPLETED';
+  } else if (isConfirmed) {
+    if (isMyParticipantRejected || isMyParticipantPending) {
+      buttonState = 'CONFIRMED_REJECTED';
+    } else if (isMyParticipantApproved) {
+      buttonState = 'CONFIRMED_APPROVED';
+    } else if (isHost) {
+      buttonState = 'CONFIRMED_HOST';
+    } else {
+      buttonState = 'CONFIRMED_DEFAULT';
+    }
+  } else if (isRecruiting) {
+    if (isHost) {
+      buttonState = 'RECRUITING_HOST';
+    } else if (isParticipating) {
+      buttonState = 'RECRUITING_PARTICIPATING';
+    } else if (showParticipationForm) {
+      buttonState = 'RECRUITING_FORM';
+    } else {
+      buttonState = 'RECRUITING_JOIN';
+    }
+  }
+
   const renderActionButtons = () => {
-    // 취소된 모임일 때
-    if (isCanceled) {
-      return (
-        <Button variant="solid" disabled className="w-[22.75rem]">
-          취소된 모임입니다
-        </Button>
-      );
-    }
-
-    // 완료된 모임일 때
-    if (isCompleted) {
-      return (
-        <Button variant="solid" disabled className="w-[22.75rem]">
-          완료된 모임입니다
-        </Button>
-      );
-    }
-
-    // 모집 마감일 때
-    if (isConfirmed) {
-      if (isMyParticipantPending || isMyParticipantRejected) {
+    switch (buttonState) {
+      case 'CANCELED':
         return (
-          <Button variant="solid" disabled className="w-[22.75rem]">
+          <Button disabled className="w-[22.75rem]">
+            취소된 모임입니다
+          </Button>
+        );
+      case 'COMPLETED':
+        return (
+          <Button disabled className="w-[22.75rem]">
+            완료된 모임입니다
+          </Button>
+        );
+      case 'CONFIRMED_REJECTED':
+        return (
+          <Button disabled className="w-[22.75rem]">
             신청 거절된 모임입니다
           </Button>
         );
-      }
-      if (isMyParticipantApproved) {
+      case 'CONFIRMED_APPROVED':
         return (
-          <Button variant="solid" disabled className="w-[22.75rem]">
+          <Button disabled className="w-[22.75rem]">
             참여 예정인 모임입니다
           </Button>
         );
-      }
-      if (isHost) {
+      case 'CONFIRMED_HOST':
         return (
-          <Button variant="solid" disabled className="w-[22.75rem]">
+          <Button disabled className="w-[22.75rem]">
             개설 확정된 모임입니다
           </Button>
         );
-      }
-      return (
-        <Button variant="solid" disabled className="w-[22.75rem]">
-          모집 마감된 모임입니다
-        </Button>
-      );
-    }
-
-    // 모집 중일 때
-    if (isRecruiting) {
-      if (isHost) return null;
-      if (isParticipating) {
+      case 'CONFIRMED_DEFAULT':
+        return (
+          <Button disabled className="w-[22.75rem]">
+            모집 마감된 모임입니다
+          </Button>
+        );
+      case 'RECRUITING_PARTICIPATING':
         return (
           <div>
-            <Button variant="solid" disabled className="w-[22.75rem]">
+            <Button disabled className="w-[22.75rem]">
               참여 완료
             </Button>
             <button
@@ -205,25 +231,26 @@ export default function GroupPage() {
             </button>
           </div>
         );
-      }
-      if (showParticipationForm) {
+      case 'RECRUITING_FORM':
         return (
           <ParticipationForm
             gathering={gatheringDetailData}
             onComplete={handleSubmitParticipation}
           />
         );
-      }
-      return (
-        <Button
-          variant="solid"
-          className="w-[22.75rem]"
-          onClick={() => setShowParticipationForm(true)}
-          disabled={!user}
-        >
-          함께하기
-        </Button>
-      );
+      case 'RECRUITING_JOIN':
+        return (
+          <Button
+            variant="solid"
+            className="w-[22.75rem]"
+            onClick={() => setShowParticipationForm(true)}
+            disabled={!user}
+          >
+            함께하기
+          </Button>
+        );
+      default:
+        return null;
     }
   };
 

--- a/src/components/products/group/MemberInfoSection.tsx
+++ b/src/components/products/group/MemberInfoSection.tsx
@@ -20,7 +20,7 @@ export default function MemberInfoSection({
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const approveMutation = useApproveParticipantMutation();
   const rejectMutation = useRejectParticipantMutation();
-  const isCanceled = gathering.status === 'CANCELED';
+  const isRecruiting = gathering.status === 'RECRUITING';
 
   const handleAccept = async () => {
     await Promise.all(
@@ -70,7 +70,7 @@ export default function MemberInfoSection({
         />
       </section>
 
-      {!isCanceled && (
+      {isRecruiting && (
         <div className="ml-[1.25rem] flex flex-col gap-[1.25rem]">
           <Button
             variant="solid"

--- a/src/components/products/group/MemberInfoSection.tsx
+++ b/src/components/products/group/MemberInfoSection.tsx
@@ -20,6 +20,7 @@ export default function MemberInfoSection({
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const approveMutation = useApproveParticipantMutation();
   const rejectMutation = useRejectParticipantMutation();
+  const isCanceled = gathering.status === 'CANCELED';
 
   const handleAccept = async () => {
     await Promise.all(
@@ -69,24 +70,26 @@ export default function MemberInfoSection({
         />
       </section>
 
-      <div className="ml-[1.25rem] flex flex-col gap-[1.25rem]">
-        <Button
-          variant="solid"
-          className="w-[22.75rem]"
-          onClick={handleAccept}
-          disabled={selectedIds.length === 0}
-        >
-          {selectedIds.length}명 수락
-        </Button>
-        <Button
-          variant="outline"
-          className="w-[22.75rem]"
-          onClick={handleReject}
-          disabled={selectedIds.length === 0}
-        >
-          {selectedIds.length}명 거절
-        </Button>
-      </div>
+      {!isCanceled && (
+        <div className="ml-[1.25rem] flex flex-col gap-[1.25rem]">
+          <Button
+            variant="solid"
+            className="w-[22.75rem]"
+            onClick={handleAccept}
+            disabled={selectedIds.length === 0}
+          >
+            {selectedIds.length}명 수락
+          </Button>
+          <Button
+            variant="outline"
+            className="w-[22.75rem]"
+            onClick={handleReject}
+            disabled={selectedIds.length === 0}
+          >
+            {selectedIds.length}명 거절
+          </Button>
+        </div>
+      )}
     </>
   );
 }

--- a/src/hooks/__tests__/useQueryTab.test.tsx
+++ b/src/hooks/__tests__/useQueryTab.test.tsx
@@ -8,11 +8,11 @@ jest.mock('next/navigation', () => ({
 }));
 
 describe('useQueryTab 훅 테스트', () => {
-  const push = jest.fn();
+  const replace = jest.fn();
 
   beforeEach(() => {
-    (useRouter as jest.Mock).mockReturnValue({ push });
-    push.mockClear();
+    (useRouter as jest.Mock).mockReturnValue({ replace });
+    replace.mockClear();
   });
 
   test('기본값을 반환해야 한다 (쿼리 없음)', () => {
@@ -68,6 +68,6 @@ describe('useQueryTab 훅 테스트', () => {
       result.current.setTab('profile');
     });
 
-    expect(push).toHaveBeenCalledWith('?tab=profile');
+    expect(replace).toHaveBeenCalledWith('?tab=profile');
   });
 });

--- a/src/hooks/queries/review/usePostReviewMutation.ts
+++ b/src/hooks/queries/review/usePostReviewMutation.ts
@@ -8,12 +8,7 @@ export const usePostReviewMutation = () => {
   return useMutation({
     mutationFn: (data: PostReviewRequest) => postReview(data),
     onSuccess: () => {
-      alert('리뷰가 등록되었습니다!');
-      queryClient.invalidateQueries({ queryKey: ['getReviewWrite'] });
-    },
-    onError: (error) => {
-      console.error('리뷰 등록 실패:', error);
-      alert('리뷰 등록 중 문제가 발생했어요.');
+      queryClient.invalidateQueries({ queryKey: ['writtenReviews'] });
     },
   });
 };

--- a/src/hooks/queries/review/useWrittenReviewsQuery.ts
+++ b/src/hooks/queries/review/useWrittenReviewsQuery.ts
@@ -1,0 +1,13 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { getWrittenReviews } from '@/lib/review/written';
+import { ReviewItem } from '@/types/review';
+
+export const useWrittenReviewsQuery = (
+  options?: Partial<UseQueryOptions<ReviewItem[]>>,
+) => {
+  return useQuery({
+    queryKey: ['writtenReviews'],
+    queryFn: getWrittenReviews,
+    ...options,
+  });
+};

--- a/src/hooks/useQueryTab.tsx
+++ b/src/hooks/useQueryTab.tsx
@@ -17,7 +17,7 @@ export function useQueryTab<T extends string>(
   const setTab = (tab: T) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set(key, tab);
-    router.push(`?${params.toString()}`);
+    router.replace(`?${params.toString()}`);
   };
 
   return {

--- a/src/lib/review/written.ts
+++ b/src/lib/review/written.ts
@@ -1,0 +1,6 @@
+import { ReviewItem } from '@/types/review';
+import { apiClient } from '@/utils/apiClient';
+
+export const getWrittenReviews = async (): Promise<ReviewItem[]> => {
+  return await apiClient.get<ReviewItem[]>('/review/written');
+};

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -4,18 +4,14 @@ import { UserResponse } from '@/types/user';
 
 interface UserState {
   user: UserResponse | null;
-  isLoaded: boolean; // 추가
+  isLoaded: boolean;
   isRefreshing: boolean;
   isLoggedIn: boolean;
 
   setUser: (user: UserResponse) => void;
   clearUser: () => void;
-
-  // setLoaded: () => void; // 추가
-  // setRefreshing: (value: boolean) => void;
   startRefresh: () => void;
   endRefresh: () => void;
-
   setLoaded: () => void;
 }
 
@@ -29,15 +25,9 @@ export const useUserStore = create<UserState>()(
 
       setUser: (user) => set({ user, isLoggedIn: true }),
       clearUser: () => set({ user: null, isLoggedIn: false }),
-
       startRefresh: () => set({ isRefreshing: true }),
       endRefresh: () => set({ isRefreshing: false }),
-
       setLoaded: () => set({ isLoaded: true }),
-
-      // setUser: (user) => set({ user, isLoggedIn: true }),
-      // clearUser: () => set({ user: null, isLoggedIn: false),
-      // setLoaded: () => set({ isLoaded: true }),
     }),
     {
       name: 'user',

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -4,9 +4,19 @@ import { UserResponse } from '@/types/user';
 
 interface UserState {
   user: UserResponse | null;
+  isLoaded: boolean; // 추가
+  isRefreshing: boolean;
   isLoggedIn: boolean;
+
   setUser: (user: UserResponse) => void;
   clearUser: () => void;
+
+  // setLoaded: () => void; // 추가
+  // setRefreshing: (value: boolean) => void;
+  startRefresh: () => void;
+  endRefresh: () => void;
+
+  setLoaded: () => void;
 }
 
 export const useUserStore = create<UserState>()(
@@ -14,11 +24,26 @@ export const useUserStore = create<UserState>()(
     (set) => ({
       user: null,
       isLoggedIn: false,
+      isLoaded: false,
+      isRefreshing: false,
+
       setUser: (user) => set({ user, isLoggedIn: true }),
       clearUser: () => set({ user: null, isLoggedIn: false }),
+
+      startRefresh: () => set({ isRefreshing: true }),
+      endRefresh: () => set({ isRefreshing: false }),
+
+      setLoaded: () => set({ isLoaded: true }),
+
+      // setUser: (user) => set({ user, isLoggedIn: true }),
+      // clearUser: () => set({ user: null, isLoggedIn: false),
+      // setLoaded: () => set({ isLoaded: true }),
     }),
     {
       name: 'user',
+      onRehydrateStorage: () => () => {
+        useUserStore.getState().setLoaded();
+      },
     },
   ),
 );

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -5,6 +5,7 @@ import { postSignup } from '@/lib/auth/signup';
 import { queryClient } from '@/lib/react-query';
 import { apiClient } from './apiClient';
 import { useUserStore } from '@/stores/useUserStore';
+import { useErrorModalStore } from '@/stores/useErrorModalStore';
 
 export const login = async (loginRequest: LoginRequest): Promise<void> => {
   const result = await postLogin(loginRequest);
@@ -33,8 +34,7 @@ export const refreshAccessToken = async (): Promise<void> => {
   try {
     const refreshToken = tokenService.getRefreshToken();
     if (!refreshToken) {
-      store.endRefresh();
-      return;
+      throw new Error('No refresh token');
     }
 
     const { accessToken } = await apiClient.post<{ accessToken: string }>(
@@ -44,6 +44,12 @@ export const refreshAccessToken = async (): Promise<void> => {
 
     tokenService.setAccessToken(accessToken);
     queryClient.invalidateQueries({ queryKey: ['me'] });
+  } catch {
+    useErrorModalStore
+      .getState()
+      .open('세션이 만료되었습니다. 다시 로그인 해주세요.');
+    tokenService.clearAllTokens();
+    store.clearUser();
   } finally {
     store.endRefresh();
   }


### PR DESCRIPTION
## 연관된 이슈

close #135 

## 작업내용
- 참여멤버 탭에서 새로고침시 403 에러 나는거 해결
- 모임 상세 액션버튼 정리 (+ 리팩토링)
- 내가 적은 리뷰 데이터 불러와서 리뷰 작성 완료한 참여자 리뷰 작성 버튼 비활성화

## 체크리스트
### 1. 인증 상태 관리 관련
새로고침해서 토큰 갱신을 하는 중에 다른 토큰이 필요한 요청을 보내는 타이밍 문제를 처리할 수 있게 useUserStore에 상태를 추가했어요.
```ts
interface UserState {
  user: UserResponse | null;
  isLoaded: boolean; // 추가: zustand 스토어가 hydration 이후 정상적으로 mount 되었는지 여부
  isRefreshing: boolean; // 추가: 토큰 리프레시 중인지 여부
  isLoggedIn: boolean;

  setUser: (user: UserResponse) => void;
  clearUser: () => void;
  startRefresh: () => void; // 추가: refreshAccessToken 함수에서 설정됨
  endRefresh: () => void; // 추가: refreshAccessToken 함수에서 설정됨
  setLoaded: () => void; // 추가
}
```
사용자 데이터나 토큰이 필요한 요청일 경우에 아래처럼 사용하시면
새로고침 리프레시 중간에 요청이 가지 않아 403을 방지할 수 있습니다!
```ts
const { user, isLoaded, isRefreshing } = useUserStore();
const isQueryReady = isLoaded && !isRefreshing && !!user; // 요청 보내지 말아야할 조건 설정

const { data, isLoading, error } = useQuery({
  queryKey: ['~~~'],
  queryFn: fetchData,
  enabled: isQueryReady, // enabled 설정
});
```

### 2. 버튼 종류 정리
![image](https://github.com/user-attachments/assets/09ecfae5-f91a-4bdd-aa1c-05a17fe94838)


## 스크린샷
<img width="1039" alt="스크린샷 2025-06-13 오후 6 58 52" src="https://github.com/user-attachments/assets/66453adf-432b-4fca-a6d6-f17e0c7addf7" />



