### PR TITLE
[기능] 사진 업로드 용량 제한 설정

### DIFF
--- a/src/components/commons/Modal/ModalEdit.tsx
+++ b/src/components/commons/Modal/ModalEdit.tsx
@@ -14,9 +14,9 @@ import {
   SESSION_ENUM_TO_KR,
   GENRE_ENUM_TO_KR,
 } from '@/constants/tagsMapping';
-import { useUploadProfileImageMutation } from '@/hooks/queries/user/useUploadProfileImageMutaion';
 import { useErrorModalStore } from '@/stores/useErrorModalStore';
 import ErrorModal from './ErrorModal';
+import { useImageUpload } from '@/hooks/useImageUpload';
 
 interface ModalEditProps {
   /** "확인" 버튼 클릭 시 실행할 콜백 */
@@ -34,8 +34,8 @@ export default function ModalEdit({
   initialData,
   userId,
 }: ModalEditProps) {
-  const { mutateAsync: uploadImage } = useUploadProfileImageMutation();
   const { message, isOpen, close } = useErrorModalStore();
+  const { handleImageUpload } = useImageUpload();
 
   // 영어 enum을 한글로 변환
   const initialSessionsKr =
@@ -62,16 +62,11 @@ export default function ModalEdit({
   const imageUrl = watch('image');
   const password = watch('password');
 
-  const MAX_FILE_SIZE = 5 * 1024 * 1024;
   const handleFileChange = async (file: File) => {
-    if (file.size > MAX_FILE_SIZE) {
-      useErrorModalStore
-        .getState()
-        .open('파일 크기는 최대 5MB까지 업로드 가능합니다.');
-      return;
+    const uploadedUrl = await handleImageUpload(userId, file);
+    if (uploadedUrl) {
+      setValue('image', uploadedUrl);
     }
-    const uploadedUrl = await uploadImage({ userId: userId, file });
-    setValue('image', uploadedUrl);
   };
 
   const handleSessionTagChange = useCallback(

--- a/src/components/commons/Modal/ModalWrapper.tsx
+++ b/src/components/commons/Modal/ModalWrapper.tsx
@@ -25,7 +25,7 @@ function ModalWrapper({
   useClickOutside(modalRef, onClose);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50">
       <div ref={modalRef} className={className}>
         <button
           onClick={onClose}

--- a/src/components/products/signup/step2/SignupStep2Page.tsx
+++ b/src/components/products/signup/step2/SignupStep2Page.tsx
@@ -18,8 +18,7 @@ import { GENRE_KR_TO_ENUM, SESSION_KR_TO_ENUM } from '@/constants/tagsMapping';
 import { GENRE_TAGS, SESSION_TAGS } from '@/constants/tags';
 import { useToastStore } from '@/stores/useToastStore';
 import ModalInteraction from '@/components/commons/Modal/ModalInteraction';
-import { useUploadProfileImageMutation } from '@/hooks/queries/user/useUploadProfileImageMutaion';
-import { useErrorModalStore } from '@/stores/useErrorModalStore';
+import { useImageUpload } from '@/hooks/useImageUpload';
 
 interface FormValues {
   image: File;
@@ -33,8 +32,8 @@ export default function SignupStep2Page() {
   const { email, name, password, resetSignupData } = useSignupStore();
   const [missingInfoModalOpen, setMissingInfoModalOpen] = useState(false);
   const [profileImageUrl, setProfileImageUrl] = useState<string>('');
-  const { mutateAsync: uploadImage } = useUploadProfileImageMutation();
   const { mutateAsync: signup } = useSignupMutation();
+  const { handleImageUpload } = useImageUpload();
 
   const hasCheckedRef = useRef(false);
 
@@ -58,16 +57,11 @@ export default function SignupStep2Page() {
     control,
   } = methods;
 
-  const MAX_FILE_SIZE = 5 * 1024 * 1024;
   const handleFileUpload = async (file: File) => {
-    if (file.size > MAX_FILE_SIZE) {
-      useErrorModalStore
-        .getState()
-        .open('파일 크기는 최대 5MB까지 업로드 가능합니다.');
-      return;
+    const uploadedUrl = await handleImageUpload(1, file);
+    if (uploadedUrl) {
+      setProfileImageUrl(uploadedUrl);
     }
-    const uploadedUrl = await uploadImage({ userId: 1, file });
-    setProfileImageUrl(uploadedUrl);
   };
 
   const handleSessionTagChange = (selected: string[]) => {

--- a/src/components/products/signup/step2/SignupStep2Page.tsx
+++ b/src/components/products/signup/step2/SignupStep2Page.tsx
@@ -19,6 +19,7 @@ import { GENRE_TAGS, SESSION_TAGS } from '@/constants/tags';
 import { useToastStore } from '@/stores/useToastStore';
 import ModalInteraction from '@/components/commons/Modal/ModalInteraction';
 import { useUploadProfileImageMutation } from '@/hooks/queries/user/useUploadProfileImageMutaion';
+import { useErrorModalStore } from '@/stores/useErrorModalStore';
 
 interface FormValues {
   image: File;
@@ -57,7 +58,14 @@ export default function SignupStep2Page() {
     control,
   } = methods;
 
+  const MAX_FILE_SIZE = 5 * 1024 * 1024;
   const handleFileUpload = async (file: File) => {
+    if (file.size > MAX_FILE_SIZE) {
+      useErrorModalStore
+        .getState()
+        .open('파일 크기는 최대 5MB까지 업로드 가능합니다.');
+      return;
+    }
     const uploadedUrl = await uploadImage({ userId: 1, file });
     setProfileImageUrl(uploadedUrl);
   };
@@ -132,7 +140,7 @@ export default function SignupStep2Page() {
                   control={control}
                   render={({ field }) => (
                     <ProfileImageUpload
-                      imageFile={field.value}
+                      imageFile={profileImageUrl}
                       onFileChange={(file) => {
                         field.onChange(file);
                         handleFileUpload(file);

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,0 +1,19 @@
+import { useUploadProfileImageMutation } from '@/hooks/queries/user/useUploadProfileImageMutaion';
+import { useErrorModalStore } from '@/stores/useErrorModalStore';
+
+export const useImageUpload = () => {
+  const { mutateAsync: uploadImage } = useUploadProfileImageMutation();
+  const { open } = useErrorModalStore();
+  const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+  const handleImageUpload = async (userId: number, file: File) => {
+    if (file.size > MAX_FILE_SIZE) {
+      open('파일 크기는 최대 5MB까지 업로드 가능합니다.');
+      return null;
+    }
+    const uploadedUrl = await uploadImage({ userId, file });
+    return uploadedUrl;
+  };
+
+  return { handleImageUpload };
+};


### PR DESCRIPTION
## 연관된 이슈

close #141

## 작업내용
- 사진 업로드 요청 보내기 전에 5MB 이하인지 검사하는 로직 추가
- 용량 초과시 "파일 크기는 최대 5MB까지 업로드 가능합니다." 모달 표시

## 체크리스트
- 경고를 모달로 안내하자니, 회원가입 부분은 상관없는데 프로필 수정 부분이 모달위에 모달을 띄우게 돼서 어색하긴 한데, 괜찮을까요?
- 토스트도 한번 해봤는데 이런 경고 메시지는 빨리 사라지는 토스트보다는 모달이 나을것같기는해요.
![image](https://github.com/user-attachments/assets/af3fe37a-0ec6-456f-b046-7c9d9aaac9dc)


## 스크린샷
