### PR TITLE
[페이지] 페이지 라이트하우스 점수 향상 및 MVP 수정

### DIFF
--- a/src/components/commons/DatePicker/DatePicker.tsx
+++ b/src/components/commons/DatePicker/DatePicker.tsx
@@ -82,7 +82,7 @@ export function DatePicker({ value, onChange }: DatePickerProps) {
           className={clsx(
             'flex h-[2.75rem] w-[13.0625rem] items-center justify-center gap-[0.625rem] rounded-[0.5rem] bg-[#34343a] px-[1rem] text-[1rem] text-gray-100',
             isOpen ? 'border border-[#505057]' : 'border-none',
-            !date && 'cursor-pointer text-gray-500',
+            !date && 'cursor-pointer text-gray-400',
           )}
         >
           {displayValue}

--- a/src/components/commons/Dropdown.tsx
+++ b/src/components/commons/Dropdown.tsx
@@ -74,6 +74,7 @@ export default function Dropdown({
           onClick={handleDropdownMenu}
           className={`flex items-center justify-between gap-[0.625rem] rounded-lg border-0 bg-[#34343A] text-gray-100 ${sizeClass} ${isProfile ? 'h-auto w-auto border-none bg-transparent p-0' : 'px-[1rem] py-[0.625rem]'}`}
           type="button"
+          aria-label="드롭다운 이미지 버튼"
         >
           {isProfile ? (
             singleIcon

--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -136,6 +136,7 @@ function Input({
             type="button"
             onClick={() => setShowPassword((prev) => !prev)}
             className="absolute top-1/2 right-3 -translate-y-1/2"
+            aria-label="비밀번호 숨김 버튼"
           >
             {showPassword ? <Visibility /> : <Invisibility />}
           </button>

--- a/src/components/commons/Modal/ModalWrapper.tsx
+++ b/src/components/commons/Modal/ModalWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, ReactNode, useRef } from 'react';
+import { memo, ReactNode, useRef, useEffect } from 'react';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import CancelIcon from '@/assets/icons/ic_x.svg';
 
@@ -23,6 +23,13 @@ function ModalWrapper({
 }: ModalWrapperProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   useClickOutside(modalRef, onClose);
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50">

--- a/src/components/products/jam/DateFormSection.tsx
+++ b/src/components/products/jam/DateFormSection.tsx
@@ -25,7 +25,7 @@ export default function DateFormSection({ control }: DateFormSectionProps) {
     <div className="flex gap-[1.25rem]">
       {DATE_FIELDS.map(({ name, label, htmlFor }) => (
         <div key={name} className="flex flex-col gap-[0.5rem]">
-          <label htmlFor={htmlFor} className="font-semibold">
+          <label htmlFor={htmlFor} className="text-sm font-semibold">
             {label}
           </label>
           <Controller

--- a/src/components/products/jam/DescriptionFormSection.tsx
+++ b/src/components/products/jam/DescriptionFormSection.tsx
@@ -11,7 +11,7 @@ export default function DescriptionFormSection({
 }: DescriptionFormSectionProps) {
   return (
     <div className="flex flex-col gap-[0.5rem]">
-      <p className="text-lg font-semibold">소개글</p>
+      <p className="text-sm font-semibold">소개글</p>
       <Controller
         name="description"
         control={control}

--- a/src/components/products/jam/GenreFormSection.tsx
+++ b/src/components/products/jam/GenreFormSection.tsx
@@ -35,7 +35,7 @@ export default function GenreFormSection({
 
   return (
     <div className="flex flex-col gap-[0.5rem]">
-      <p className="text-lg font-semibold">모임 장르</p>
+      <p className="text-sm font-semibold">모임 장르</p>
       <TagSelector
         mode="selectable"
         tags={GENRE_TAGS}

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -35,7 +35,7 @@ export default function JamFormSection({
   );
 
   return (
-    <div className="mt-[2.5rem] flex h-auto w-[61rem] flex-col bg-[#202024] p-[2.5rem]">
+    <div className="mt-[2.5rem] flex h-auto w-[61rem] flex-col bg-[#1A1A1E] p-[2.5rem]">
       <div className="flex flex-col gap-[1.5rem]">
         {/** 모임 제목 */}
         <Input

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -2,6 +2,7 @@
 
 import { FormProvider, useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import ImageEdit from '@/components/products/jam/ImageEdit';
 import GroupPageLayout from '@/components/commons/GroupPageLayout';
 import Button from '@/components/commons/Button';
@@ -9,6 +10,8 @@ import JamFormSection from '@/components/products/jam/JamFormSection';
 import { RegisterGatheringsRequest } from '@/types/gather';
 import { useGatherRegister } from '@/hooks/queries/gather/useGatherRegister';
 import { useGatherModify } from '@/hooks/queries/gather/useGatherModify';
+import { useUserStore } from '@/stores/useUserStore';
+import ModalInteraction from '@/components/commons/Modal/ModalInteraction';
 
 interface JamPageProps {
   formType?: 'register' | 'edit';
@@ -22,6 +25,20 @@ export default function JamPage({
   initialData,
 }: JamPageProps) {
   const router = useRouter();
+  const isLoggedIn = useUserStore((state) => state.isLoggedIn);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      setShowLoginModal(true);
+    }
+  }, [isLoggedIn]);
+
+  const handleLoginModalClose = () => {
+    setShowLoginModal(false);
+    router.push('/login');
+  };
+
   const methods = useForm<RegisterGatheringsRequest>({
     defaultValues: initialData ?? {
       name: '',
@@ -99,6 +116,14 @@ export default function JamPage({
           />
         </GroupPageLayout>
       </form>
+      {showLoginModal && (
+        <ModalInteraction
+          message="로그인 페이지로 이동하시겠습니까?"
+          onConfirm={handleLoginModalClose}
+          onClose={handleLoginModalClose}
+          isShowCancel={false}
+        />
+      )}
     </FormProvider>
   );
 }

--- a/src/components/products/jam/ModalImgEdit.tsx
+++ b/src/components/products/jam/ModalImgEdit.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { memo, useRef, useState } from 'react';
+import { memo, useRef, useState, useEffect } from 'react';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import Button from '@/components/commons/Button';
 import { imgChange } from '@/utils/imgChange';
@@ -19,6 +19,13 @@ function ModalImgEdit({ onSubmit, onClose }: ModalImgEditProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [visibleCount, setVisibleCount] = useState(FIRST_RENDERING);
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
 
   useClickOutside(modalRef, onClose);
 

--- a/src/components/products/jam/SearchInput.tsx
+++ b/src/components/products/jam/SearchInput.tsx
@@ -20,7 +20,7 @@ export default function SearchInput({ value, onChange }: SearchInputProps) {
     }
     const script = document.createElement('script');
     script.src =
-      '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+      'https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
     script.async = true;
     document.body.appendChild(script);
   }, []);

--- a/src/components/products/jam/SearchInput.tsx
+++ b/src/components/products/jam/SearchInput.tsx
@@ -58,6 +58,7 @@ export default function SearchInput({ value, onChange }: SearchInputProps) {
           type="button"
           className="absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer"
           onClick={handleSearchClick}
+          aria-label="모임 장소 찾기 버튼"
         >
           <SearchIcon />
         </button>

--- a/src/components/products/jam/SearchInput.tsx
+++ b/src/components/products/jam/SearchInput.tsx
@@ -1,33 +1,19 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import Script from 'next/script';
 import SearchIcon from '@/assets/icons/ic_search.svg';
 
 interface SearchInputProps {
-  /** 입력한 주소 */
   value: string;
-  /** 주소 선택시 값 전달 */
   onChange: (val: string) => void;
 }
 
 export default function SearchInput({ value, onChange }: SearchInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    // 이미 로드된 경우 추가 안 함
-    if (window.daum?.Postcode) {
-      return;
-    }
-    const script = document.createElement('script');
-    script.src =
-      'https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
-    script.async = true;
-    document.body.appendChild(script);
-  }, []);
-
   const handleSearchClick = () => {
     const { daum } = window;
-
     if (!daum?.Postcode) {
       return;
     }
@@ -39,30 +25,36 @@ export default function SearchInput({ value, onChange }: SearchInputProps) {
         inputRef.current?.focus();
       },
     });
-
     postcode.open();
   };
 
   return (
-    <div className="flex flex-col gap-[0.5rem]">
-      <label className="block text-sm text-gray-100">모임 장소</label>
-      <div className="relative w-[27.9375rem] text-gray-400">
-        <input
-          ref={inputRef}
-          value={value}
-          placeholder="장소명을 검색하세요."
-          readOnly
-          className="h-[2.75rem] w-full rounded-lg border-0 bg-[#34343A] px-[1rem] py-[0.625rem]"
-        />
-        <button
-          type="button"
-          className="absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer"
-          onClick={handleSearchClick}
-          aria-label="모임 장소 찾기 버튼"
-        >
-          <SearchIcon />
-        </button>
+    <>
+      <Script
+        src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"
+        strategy="lazyOnload"
+      />
+
+      <div className="flex flex-col gap-[0.5rem]">
+        <label className="block text-sm text-gray-100">모임 장소</label>
+        <div className="relative w-[27.9375rem] text-gray-400">
+          <input
+            ref={inputRef}
+            value={value}
+            placeholder="장소명을 검색하세요."
+            readOnly
+            className="h-[2.75rem] w-full rounded-lg border-0 bg-[#34343A] px-[1rem] py-[0.625rem]"
+          />
+          <button
+            type="button"
+            className="absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer"
+            onClick={handleSearchClick}
+            aria-label="모임 장소 찾기 버튼"
+          >
+            <SearchIcon />
+          </button>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/products/jam/SearchInput.tsx
+++ b/src/components/products/jam/SearchInput.tsx
@@ -38,21 +38,24 @@ export default function SearchInput({ value, onChange }: SearchInputProps) {
       <div className="flex flex-col gap-[0.5rem]">
         <label className="block text-sm text-gray-100">모임 장소</label>
         <div className="relative w-[27.9375rem] text-gray-400">
-          <input
-            ref={inputRef}
-            value={value}
-            placeholder="장소명을 검색하세요."
-            readOnly
-            className="h-[2.75rem] w-full rounded-lg border-0 bg-[#34343A] px-[1rem] py-[0.625rem]"
-          />
-          <button
-            type="button"
-            className="absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer"
-            onClick={handleSearchClick}
-            aria-label="모임 장소 찾기 버튼"
-          >
-            <SearchIcon />
-          </button>
+          <label className="block cursor-pointer">
+            <input
+              ref={inputRef}
+              value={value}
+              placeholder="장소명을 검색하세요."
+              readOnly
+              className="h-[2.75rem] w-full rounded-lg border-0 bg-[#34343A] px-[1rem] py-[0.625rem]"
+              onClick={handleSearchClick}
+            />
+            <button
+              type="button"
+              className="absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer"
+              onClick={handleSearchClick}
+              aria-label="모임 장소 찾기 버튼"
+            >
+              <SearchIcon />
+            </button>
+          </label>
         </div>
       </div>
     </>

--- a/src/components/products/jam/SessionFormSection.tsx
+++ b/src/components/products/jam/SessionFormSection.tsx
@@ -87,7 +87,7 @@ export default function SessionFormSection({
 
   return (
     <div className="flex flex-col gap-[0.5rem]">
-      <p className="text-lg font-semibold">모집 세션</p>
+      <p className="text-sm font-semibold">모집 세션</p>
       <div className="flex flex-row justify-between">
         <div className="flex flex-col gap-[0.75rem]">
           {sessionList.map(({ sortOption, count }, index) => (

--- a/src/components/products/jam/SessionFormSection.tsx
+++ b/src/components/products/jam/SessionFormSection.tsx
@@ -104,7 +104,12 @@ export default function SessionFormSection({
           ))}
         </div>
         <div className="flex gap-[0.75rem]">
-          <Button variant="outline" size="small" onClick={handleAddSession}>
+          <Button
+            variant="outline"
+            size="small"
+            onClick={handleAddSession}
+            className="text-gray-100 hover:text-white"
+          >
             추가
           </Button>
           <Button
@@ -112,6 +117,7 @@ export default function SessionFormSection({
             size="small"
             onClick={() => handleDeleteSession(sessionList.length - 1)}
             disabled={sessionList.length === 1}
+            className="text-gray-100 hover:text-white"
           >
             삭제
           </Button>

--- a/src/components/products/mypage/UserCard.tsx
+++ b/src/components/products/mypage/UserCard.tsx
@@ -18,9 +18,8 @@ export default function UserCard() {
   const updateProfile = useUpdateProfile();
   const updateProfileImage = useUpdateProfileImage();
   const { data: user, isLoading } = useUserMeQuery();
-  const { user: storeUser, setUser } = useUserStore();
+  const { setUser } = useUserStore();
 
-  // TODO: 토큰 로직 리팩토링 이후 작업 시작
   if (isLoading || !user) {
     return (
       <div className="flex h-[15.625rem] w-[full] items-center justify-center gap-[3.3125rem] bg-[#36114E]">
@@ -28,8 +27,6 @@ export default function UserCard() {
       </div>
     );
   }
-
-  const displayUser = storeUser || user;
 
   const handleProfileEdit = () => {
     setIsModalOpen(true);
@@ -58,7 +55,7 @@ export default function UserCard() {
         );
 
         const updatedUser = {
-          ...displayUser,
+          ...user,
           username: data.username,
           preferredGenres: data.preferredGenres,
           preferredBandSessions: data.preferredBandSessions,
@@ -78,7 +75,7 @@ export default function UserCard() {
         <div className="flex flex-col text-gray-100">
           <div className="flex items-center gap-[0.625rem]">
             <p className="text-[1.5rem] leading-[2.4rem] font-bold">
-              {displayUser.username}
+              {user.username}
             </p>
             <button
               type="submit"
@@ -90,7 +87,7 @@ export default function UserCard() {
           </div>
           <div className="flex items-center gap-[0.5rem] text-sm font-medium">
             <p>담당 세션</p>
-            {displayUser.preferredBandSessions.map((session: BandSession) => (
+            {user.preferredBandSessions.map((session: BandSession) => (
               <div
                 key={session}
                 className="h-[2rem] rounded-lg bg-[#34343A] px-[0.75rem] py-[0.375rem]"
@@ -100,7 +97,7 @@ export default function UserCard() {
             ))}
             <div className="h-[1.25rem] w-[0.0938rem] bg-gray-500" />
             <p>선호 장르</p>
-            {displayUser.preferredGenres.map((genre: Genre) => (
+            {user.preferredGenres.map((genre: Genre) => (
               <div
                 key={genre}
                 className="h-[2rem] rounded-lg bg-[#34343A] px-[0.75rem] py-[0.375rem]"
@@ -122,16 +119,15 @@ export default function UserCard() {
         <ModalEdit
           onCancel={handleModalCancel}
           onSubmit={handleModalSubmit}
-          // TODO: GET API 가져오기
           initialData={{
-            email: displayUser.email,
+            email: user.email,
             password: null,
-            username: displayUser.username,
-            image: displayUser.profileImagePath,
-            preferredBandSessions: displayUser.preferredBandSessions,
-            preferredGenres: displayUser.preferredGenres,
+            username: user.username,
+            image: user.profileImagePath,
+            preferredBandSessions: user.preferredBandSessions,
+            preferredGenres: user.preferredGenres,
           }}
-          userId={displayUser.id}
+          userId={user.id}
         />
       )}
     </>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -126,9 +126,13 @@
     border-spacing: 0;
   }
 
-  input:-webkit-autofill {
-    -webkit-box-shadow: 0 0 0 1000px #34343a inset;
-    -webkit-text-fill-color: white;
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    -webkit-box-shadow: 0 0 0 1000px #34343a inset !important;
+    -webkit-text-fill-color: gray-400 !important;
+    transition: background-color 5000s ease-in-out 0s;
   }
 
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -131,8 +131,10 @@
   input:-webkit-autofill:focus,
   input:-webkit-autofill:active {
     -webkit-box-shadow: 0 0 0 1000px #34343a inset !important;
-    -webkit-text-fill-color: gray-400 !important;
+    -webkit-text-fill-color: #9CA3AF !important;
     transition: background-color 5000s ease-in-out 0s;
+    font-size: 1rem !important;
+    font-weight: 500 !important;
   }
 
 }

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -25,6 +25,7 @@ export const signup = async (signupRequest: SignupRequest): Promise<void> => {
 export const logout = async (): Promise<void> => {
   useUserStore.getState().clearUser();
   tokenService.clearAllTokens();
+  queryClient.clear();
 };
 
 export const refreshAccessToken = async (): Promise<void> => {


### PR DESCRIPTION
## 연관된 이슈

close #140 

## 작업내용
- usercard 다른 계정 로그인시 이전 로그인 계정 데이터 남아있는 버그 수정
- aria-label 추가
- 색상대비 추가
- formsection 폰트 크기 수정
- input 관련 자동완성 global.css 수정
- dim요소 스크롤 차단
- 모임 만들기 페이지에서 로그인 안되어있으면 경고성모달과 함께 '확인'버튼이나 'x'버튼 클릭 시 로그인 페이지 이동
- 모임 장소 label 추가해서 버튼 클릭시가 아닌 전체 요소 클릭시로 변경

## 체크리스트
- 라이트하우스 권장 사항이 낮은 것들은 api GET 호출 페이지인데, 지금 컴퓨터에서 https 통신으로 연동된 백엔드 서버가 fetch오류가 나서 기존 http통신하는 백엔드 서버와 한거라 무시하셔도 됩니다. 
- 색상 변경이 심한 부분은 성능점수가 4 ~ 5점 낮게 책정됩니다.

## 스크린샷
- input 자동완성시
<img width="211" alt="스크린샷 2025-06-16 오후 2 38 32" src="https://github.com/user-attachments/assets/740a4ea3-9af8-451a-b2d1-e1ab0f128e1c" />

- 로그인 안되어있을때 모임 생성 페이지 이동시
<img width="625" alt="스크린샷 2025-06-16 오후 2 39 15" src="https://github.com/user-attachments/assets/2b092c55-460a-46ed-ab5e-56b5a3f87d4c" />

- 메인페이지 라이트하우스 점수
<img width="442" alt="스크린샷 2025-06-16 오후 2 33 24" src="https://github.com/user-attachments/assets/1b609e4e-3009-429a-bfd3-f979c5950658" />

- 모임생성페이지 라이트하우스 점수
<img width="430" alt="스크린샷 2025-06-16 오전 9 53 59" src="https://github.com/user-attachments/assets/e3520708-b3cf-4e39-9a90-fb99ad83fe0a" />

- 모임수정페이지 라이트하우스 점수
<img width="681" alt="스크린샷 2025-06-16 오전 11 40 38" src="https://github.com/user-attachments/assets/1dc49c5d-d2a9-4ff3-a053-f728d2f760f6" />

- 로그인페이지 라이트하우스 점수
<img width="457" alt="스크린샷 2025-06-16 오후 2 26 25" src="https://github.com/user-attachments/assets/694518cf-5039-460b-9bc8-3516cd214698" />

- 회원가입페이지 step1 라이트하우스 점수
<img width="482" alt="스크린샷 2025-06-16 오후 2 28 53" src="https://github.com/user-attachments/assets/5a573d48-440b-4e38-aede-b36fb58427de" />

- 회원가입페이지 step2 라이트하우스 점수
<img width="481" alt="스크린샷 2025-06-16 오후 2 31 36" src="https://github.com/user-attachments/assets/c1fd2243-5955-47ab-be32-d2b3792708d1" />

- 모임상세페이지 라이트하우스 점수(참여멤버와 동일하여 하나로 대체)
<img width="469" alt="스크린샷 2025-06-16 오후 2 34 05" src="https://github.com/user-attachments/assets/b557b160-ca48-4a54-bd91-12d92781831f" />

- 마이페이지(모임) 라이트하우스 점수 -> 이 부분도 생성과 참여와 동일하여 하나로 대체
<img width="471" alt="스크린샷 2025-06-16 오후 2 35 50" src="https://github.com/user-attachments/assets/759babee-d3df-43bb-8666-2a2cf3e831d5" />

- 마이페이지(내가 달 리뷰) 라이트하우스 점수
<img width="472" alt="스크린샷 2025-06-16 오후 2 37 06" src="https://github.com/user-attachments/assets/758e375c-f77d-4f20-a3ad-b40c133ff90d" />

- 마이페이지(내가 받은 리뷰) 라이트하우스 점수
<img width="466" alt="스크린샷 2025-06-16 오후 2 36 32" src="https://github.com/user-attachments/assets/b460460c-5cb0-4cb5-9238-579ecab9b4ce" />

- 찜페이지 라이트하우스 점수
<img width="457" alt="스크린샷 2025-06-16 오후 2 37 58" src="https://github.com/user-attachments/assets/64bec7cd-d5fb-4022-a162-2590eb23a405" />

