### PR TITLE
[기능개선] 모달 리액트 포탈 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,11 +40,13 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <GlobalErrorModalProvider />
-        <Toast />
-        <Providers>
-          <Layout>{children}</Layout>
-        </Providers>
+        <div id="modal-root">
+          <GlobalErrorModalProvider />
+          <Toast />
+          <Providers>
+            <Layout>{children}</Layout>
+          </Providers>
+        </div>
       </body>
     </html>
   );

--- a/src/components/commons/Modal/ModalWrapper.tsx
+++ b/src/components/commons/Modal/ModalWrapper.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { memo, ReactNode, useRef } from 'react';
+import { memo, ReactNode, useRef, useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { usePreventScroll } from '@/hooks/usePreventScroll';
 import CancelIcon from '@/assets/icons/ic_x.svg';
@@ -23,10 +24,17 @@ function ModalWrapper({
   className,
 }: ModalWrapperProps) {
   const modalRef = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+
   useClickOutside(modalRef, onClose);
   usePreventScroll();
 
-  return (
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  const modalContent = (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50">
       <div ref={modalRef} className={className}>
         <button
@@ -44,6 +52,13 @@ function ModalWrapper({
         {children}
       </div>
     </div>
+  );
+
+  if (!mounted) return null;
+
+  return createPortal(
+    modalContent,
+    document.getElementById('modal-root') as HTMLElement,
   );
 }
 

--- a/src/components/commons/Modal/ModalWrapper.tsx
+++ b/src/components/commons/Modal/ModalWrapper.tsx
@@ -54,7 +54,9 @@ function ModalWrapper({
     </div>
   );
 
-  if (!mounted) return null;
+  if (!mounted) {
+    return null;
+  }
 
   return createPortal(
     modalContent,

--- a/src/components/commons/__tests__/ModalInteraction.test.tsx
+++ b/src/components/commons/__tests__/ModalInteraction.test.tsx
@@ -14,14 +14,12 @@ describe('ModalInteraction 렌더링 테스트', () => {
   beforeEach(() => {
     onConfirmMock.mockClear();
     onCloseMock.mockClear();
-    // 테스트 환경에 modal-root div 추가
     const modalRoot = document.createElement('div');
     modalRoot.setAttribute('id', 'modal-root');
     document.body.appendChild(modalRoot);
   });
 
   afterEach(() => {
-    // 테스트 후 modal-root div 제거
     const modalRoot = document.getElementById('modal-root');
     if (modalRoot) {
       document.body.removeChild(modalRoot);

--- a/src/components/commons/__tests__/ModalInteraction.test.tsx
+++ b/src/components/commons/__tests__/ModalInteraction.test.tsx
@@ -14,6 +14,18 @@ describe('ModalInteraction 렌더링 테스트', () => {
   beforeEach(() => {
     onConfirmMock.mockClear();
     onCloseMock.mockClear();
+    // 테스트 환경에 modal-root div 추가
+    const modalRoot = document.createElement('div');
+    modalRoot.setAttribute('id', 'modal-root');
+    document.body.appendChild(modalRoot);
+  });
+
+  afterEach(() => {
+    // 테스트 후 modal-root div 제거
+    const modalRoot = document.getElementById('modal-root');
+    if (modalRoot) {
+      document.body.removeChild(modalRoot);
+    }
   });
 
   test('메세지와 버튼 렌더링 되는지?', () => {

--- a/src/components/commons/__tests__/ModalReview.test.tsx
+++ b/src/components/commons/__tests__/ModalReview.test.tsx
@@ -8,48 +8,61 @@ jest.mock('@/assets/icons/ic_Invisibility.svg', () => {
 });
 
 describe('ModalReview 렌데링 테스트', () => {
-  const mockOnSubmit = jest.fn();
-  const mockOnCancel = jest.fn();
+  const onCancelMock = jest.fn();
+  const onSubmitMock = jest.fn();
+
+  beforeEach(() => {
+    onCancelMock.mockClear();
+    onSubmitMock.mockClear();
+    // 테스트 환경에 modal-root div 추가
+    const modalRoot = document.createElement('div');
+    modalRoot.setAttribute('id', 'modal-root');
+    document.body.appendChild(modalRoot);
+  });
+
+  afterEach(() => {
+    // 테스트 후 modal-root div 제거
+    const modalRoot = document.getElementById('modal-root');
+    if (modalRoot) {
+      document.body.removeChild(modalRoot);
+    }
+  });
 
   test('모달이 렌더링', () => {
     render(
       <ModalReview
-        revieweeNickname="잼잼러"
-        onSubmit={mockOnSubmit}
-        onCancel={mockOnCancel}
+        onCancel={onCancelMock}
+        onSubmit={onSubmitMock}
+        revieweeNickname="테스트"
       />,
     );
+
     expect(screen.getByText('리뷰쓰기')).toBeInTheDocument();
-    expect(
-      screen.getByText('잼잼러님과의 합주 경험은 어땠나요?'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('경험에 대해 자유롭게 남겨주세요.(선택)'),
-    ).toBeInTheDocument();
   });
 
   test('취소 버튼 클릭 시 onCancel 호출', () => {
     render(
       <ModalReview
-        revieweeNickname="잼잼러"
-        onSubmit={mockOnSubmit}
-        onCancel={mockOnCancel}
+        onCancel={onCancelMock}
+        onSubmit={onSubmitMock}
+        revieweeNickname="테스트"
       />,
     );
-    const cancelButton = screen.getByText('취소');
-    fireEvent.click(cancelButton);
-    expect(mockOnCancel).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /모달 닫기/i }));
+    expect(onCancelMock).toHaveBeenCalledTimes(1);
   });
 
   test('리뷰 등록 버튼은 조건을 만족해야 활성화', () => {
     render(
       <ModalReview
-        revieweeNickname="잼잼러"
-        onSubmit={mockOnSubmit}
-        onCancel={mockOnCancel}
+        onCancel={onCancelMock}
+        onSubmit={onSubmitMock}
+        revieweeNickname="테스트"
       />,
     );
-    const submitButton = screen.getByText('리뷰 등록') as HTMLButtonElement;
-    expect(submitButton.disabled).toBe(true);
+
+    const submitButton = screen.getByRole('button', { name: '리뷰 등록' });
+    expect(submitButton).toBeDisabled();
   });
 });

--- a/src/components/commons/__tests__/ModalReview.test.tsx
+++ b/src/components/commons/__tests__/ModalReview.test.tsx
@@ -14,14 +14,12 @@ describe('ModalReview 렌데링 테스트', () => {
   beforeEach(() => {
     onCancelMock.mockClear();
     onSubmitMock.mockClear();
-    // 테스트 환경에 modal-root div 추가
     const modalRoot = document.createElement('div');
     modalRoot.setAttribute('id', 'modal-root');
     document.body.appendChild(modalRoot);
   });
 
   afterEach(() => {
-    // 테스트 후 modal-root div 제거
     const modalRoot = document.getElementById('modal-root');
     if (modalRoot) {
       document.body.removeChild(modalRoot);

--- a/src/components/commons/__tests__/ModalWrapper.test.tsx
+++ b/src/components/commons/__tests__/ModalWrapper.test.tsx
@@ -12,14 +12,12 @@ describe('ModalWrapper 렌더링 테스트', () => {
 
   beforeEach(() => {
     onCloseMock.mockClear();
-    // 테스트 환경에 modal-root div 추가
     const modalRoot = document.createElement('div');
     modalRoot.setAttribute('id', 'modal-root');
     document.body.appendChild(modalRoot);
   });
 
   afterEach(() => {
-    // 테스트 후 modal-root div 제거
     const modalRoot = document.getElementById('modal-root');
     if (modalRoot) {
       document.body.removeChild(modalRoot);

--- a/src/components/commons/__tests__/ModalWrapper.test.tsx
+++ b/src/components/commons/__tests__/ModalWrapper.test.tsx
@@ -12,6 +12,18 @@ describe('ModalWrapper 렌더링 테스트', () => {
 
   beforeEach(() => {
     onCloseMock.mockClear();
+    // 테스트 환경에 modal-root div 추가
+    const modalRoot = document.createElement('div');
+    modalRoot.setAttribute('id', 'modal-root');
+    document.body.appendChild(modalRoot);
+  });
+
+  afterEach(() => {
+    // 테스트 후 modal-root div 제거
+    const modalRoot = document.getElementById('modal-root');
+    if (modalRoot) {
+      document.body.removeChild(modalRoot);
+    }
   });
 
   test('제목과 내용이 잘 렌더링 되는지?', () => {

--- a/src/components/products/jam/ModalImgEdit.tsx
+++ b/src/components/products/jam/ModalImgEdit.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { memo, useRef, useState, useEffect } from 'react';
+import { memo, useRef, useState } from 'react';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import Button from '@/components/commons/Button';
 import { imgChange } from '@/utils/imgChange';
@@ -21,16 +21,8 @@ function ModalImgEdit({ onSubmit, onClose }: ModalImgEditProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [visibleCount, setVisibleCount] = useState(FIRST_RENDERING);
 
-  usePreventScroll();
-
-  useEffect(() => {
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, []);
-
   useClickOutside(modalRef, onClose);
+  usePreventScroll();
 
   // 배너 이미지 파일명 생성 함수
   const getBannerFileName = (index: number): string => {

--- a/src/components/products/jam/ModalImgEdit.tsx
+++ b/src/components/products/jam/ModalImgEdit.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Image from 'next/image';
-import { memo, useRef, useState } from 'react';
+import { memo, useRef, useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import Button from '@/components/commons/Button';
 import { imgChange } from '@/utils/imgChange';
@@ -20,9 +21,15 @@ function ModalImgEdit({ onSubmit, onClose }: ModalImgEditProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [visibleCount, setVisibleCount] = useState(FIRST_RENDERING);
+  const [mounted, setMounted] = useState(false);
 
   useClickOutside(modalRef, onClose);
   usePreventScroll();
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
 
   // 배너 이미지 파일명 생성 함수
   const getBannerFileName = (index: number): string => {
@@ -34,7 +41,7 @@ function ModalImgEdit({ onSubmit, onClose }: ModalImgEditProps) {
     setVisibleCount((prev) => Math.min(prev + 6, TOTAL_IMAGES));
   };
 
-  return (
+  const modalContent = (
     <>
       <div
         className="fixed top-0 left-0 z-40 h-screen w-screen bg-transparent backdrop-blur-sm"
@@ -105,6 +112,15 @@ function ModalImgEdit({ onSubmit, onClose }: ModalImgEditProps) {
         </div>
       </div>
     </>
+  );
+
+  if (!mounted) {
+    return null;
+  }
+
+  return createPortal(
+    modalContent,
+    document.getElementById('modal-root') as HTMLElement,
   );
 }
 


### PR DESCRIPTION
## 연관된 이슈

close #149 

## 작업내용
- 리액트 포탈 도입
- 포탈 도입해서 테스트 코드 포탈에 관한 코드 추가 

## 체크리스트
- 혹시라도 모달 래퍼 사용안한 모달 있으면 알려주세요~
- 저도 이번에 알게된 개념이라 간략하게 설명하자면, 부모 컴포넌트의 DOM 계층 밖에 있는 DOM 노드에 React 컴포넌트를 렌더링할 수 있게 해주는 기능으로, 일반적인 컴포넌트는 <div id="root"> 내부에서 렌더링되지만, 포탈을 사용하면 root 외부에 있는 다른 DOM 요소에도 렌더링이 가능하고, 주요 이점으로 CSS overflow, z-index 문제 해결, 브라우저 전체에서 위치 고정된 UI 구현 가능, 부모 요소 스타일 간섭 없이 렌더링 가능하다는 이점이 있고, 논리적 트리(컴포넌트 계층)는 변하지 않아요.
- https://react.dev/reference/react-dom/createPortal 공식 문서 주소입니다! 
 
## 스크린샷
- 리액트 포탈 사용전(호버한 곳이 모달)
<img width="468" alt="스크린샷 2025-06-16 오후 5 47 33" src="https://github.com/user-attachments/assets/4cc59f13-3c94-4a84-83d3-099bc10d8d63" />

- 리액트 포탈 사용후(호버한 곳이 모달)
<img width="484" alt="스크린샷 2025-06-16 오후 6 05 01" src="https://github.com/user-attachments/assets/5e17d4ef-8d40-4958-87a4-194de3b6f701" />
