### PR TITLE
[레이아웃] 모임상세 참여멤버 탭 반응형

### DIFF
--- a/src/components/commons/GroupPageLayout.tsx
+++ b/src/components/commons/GroupPageLayout.tsx
@@ -72,7 +72,7 @@ export default function GroupPageLayout({
         </div>
       )}
 
-      <div className="pc:flex-row pc:px-0 pc:gap-0 mx-auto flex w-full max-w-[84rem] flex-col justify-between gap-[14px] px-5 pb-[3.875rem]">
+      <div className="pc:flex-row pc:px-0 pc:gap-0 tab:px-[1.5rem] mx-auto flex w-full max-w-[84rem] flex-col justify-between gap-[0.875rem] px-[1.125rem] pb-[3.875rem]">
         {/* 메인 본문 */}
         {children}
 

--- a/src/components/products/group/GroupInfoSection.tsx
+++ b/src/components/products/group/GroupInfoSection.tsx
@@ -67,9 +67,9 @@ export default function GroupInfoSection({
 
   return (
     <>
-      <section className="pc:max-w-[960px] tab:p-[40px] w-full rounded-[8px] bg-[#202024] p-[20px]">
+      <section className="pc:max-w-[60rem] tab:p-[2.5rem] w-full rounded-[0.5rem] bg-[#202024] p-[1.25rem]">
         {/* 모임 제목, 주최자 */}
-        <div className="relative flex flex-col gap-[10px]">
+        <div className="relative flex flex-col gap-[0.625rem]">
           <div className="flex w-full justify-between">
             <h1 className="group-info-title">{name}</h1>
           </div>
@@ -88,10 +88,10 @@ export default function GroupInfoSection({
         {/* 모임 장소, 날짜, 모집 종료일 */}
         <div className="pc:gap-2 flex flex-col text-sm">
           <div className="group-info-text">
-            <span className="group-info-subtitle mr-[8px]">모임 장소 </span>
+            <span className="group-info-subtitle mr-[0.5rem]">모임 장소 </span>
             {place}
           </div>
-          <div className="pc:flex-row pc:gap-[40px] mt-[20px] flex flex-col gap-[20px]">
+          <div className="pc:flex-row pc:gap-[2.5rem] mt-[1.25rem] flex flex-col gap-[1.25rem]">
             {[
               {
                 label: '모임 날짜',
@@ -103,7 +103,7 @@ export default function GroupInfoSection({
               },
             ].map(({ label, value }) => (
               <div key={label} className="group-info-text">
-                <span className="group-info-subtitle mr-[8px]">{label}</span>
+                <span className="group-info-subtitle mr-[0.5rem]">{label}</span>
                 {value}
               </div>
             ))}
@@ -113,19 +113,19 @@ export default function GroupInfoSection({
         <div className="group-info-divider-line" />
 
         {/* 모집 현황 */}
-        <div className="pc:flex-row flex flex-col gap-[20px]">
+        <div className="pc:flex-row flex flex-col gap-[1.25rem]">
           <div>
-            <p className="group-info-subtitle mb-[20px]">모집 현황</p>
-            <div className="grid w-[301.008px] grid-cols-2 gap-x-[32px] gap-y-[8px]">
+            <p className="group-info-subtitle mb-[1.25rem]">모집 현황</p>
+            <div className="grid w-[18.813rem] grid-cols-2 gap-x-[2rem] gap-y-[0.5rem]">
               {sessions.map(({ bandSession, currentCount, recruitCount }) => (
                 <div
                   key={bandSession}
-                  className="flex w-[142px] items-center justify-between"
+                  className="flex w-[8.875rem] items-center justify-between"
                 >
-                  <span className="rounded-[8px] bg-[#34343a] px-[12px] py-[6px] text-sm text-[14px] text-white">
+                  <span className="rounded-[0.5rem] bg-[#34343a] px-[0.75rem] py-[0.375rem] text-sm text-[0.875rem] text-white">
                     {SESSION_ENUM_TO_KR[bandSession]}
                   </span>
-                  <span className="group-info-text w-[46px]">
+                  <span className="group-info-text w-[2.875rem]">
                     {currentCount}/{recruitCount}
                   </span>
                 </div>
@@ -134,8 +134,8 @@ export default function GroupInfoSection({
           </div>
 
           {/* 모임 장르 */}
-          <div className="pc:w-[519.008px] w-full">
-            <p className="group-info-subtitle mb-[20px]">모임 장르</p>
+          <div className="pc:w-[32.438rem] w-full">
+            <p className="group-info-subtitle mb-[1.25rem]">모임 장르</p>
             <TagSelector
               tags={GENRE_TAGS}
               mode="readonly"
@@ -147,20 +147,20 @@ export default function GroupInfoSection({
         <div className="group-info-divider-line" />
 
         {/* 모임 소개글 */}
-        <p className="group-info-subtitle mb-[20px]">모임 소개글</p>
+        <p className="group-info-subtitle mb-[1.25rem]">모임 소개글</p>
         <div className="group-info-text break-keep whitespace-pre-line">
           {description}
         </div>
       </section>
 
-      <div className="ml-[20px]">
+      <div className="ml-[1.25rem]">
         {isRecruiting && isHost && (
-          <div className="flex flex-col gap-[20px]">
+          <div className="flex flex-col gap-[1.25rem]">
             {actionButtons.map(({ label, variant, onClick }) => (
               <Button
                 key={label}
                 variant={variant as 'solid' | 'outline'}
-                className="pc:w-[364px] w-full"
+                className="pc:w-[22.75rem] w-full"
                 onClick={onClick}
               >
                 {label}

--- a/src/components/products/group/GroupInfoSection.tsx
+++ b/src/components/products/group/GroupInfoSection.tsx
@@ -67,20 +67,20 @@ export default function GroupInfoSection({
 
   return (
     <>
-      <section className="pc:max-w-[60rem] w-full rounded-[0.5rem] bg-[#202024] p-[2.5rem]">
+      <section className="pc:max-w-[960px] tab:p-[40px] w-full rounded-[8px] bg-[#202024] p-[20px]">
         {/* 모임 제목, 주최자 */}
-        <div className="flex h-[4.375rem] flex-col justify-between">
+        <div className="relative flex flex-col gap-[10px]">
           <div className="flex w-full justify-between">
-            <h1 className="group-info-title">{name}</h1>
-            <div className="relative">
-              <ShareIcon
-                className="absolute top-1.5 right-[2.5rem] w-7 cursor-pointer"
-                onClick={() => setIsShareModalOpen(true)}
-              />
-              <Like item={convertToCardItem(gathering)} />
-            </div>
+            <h1 className="group-info-title break-keep">{name}</h1>
           </div>
           <p className="group-info-subtitle">{creator.nickname}</p>
+          <ShareIcon
+            className="pc:top-0 absolute right-10 bottom-0 w-7 cursor-pointer"
+            onClick={() => setIsShareModalOpen(true)}
+          />
+          <div className="pc:top-[-4] absolute right-0 bottom-7">
+            <Like item={convertToCardItem(gathering)} />
+          </div>
         </div>
 
         <div className="group-info-divider-line" />
@@ -88,10 +88,10 @@ export default function GroupInfoSection({
         {/* 모임 장소, 날짜, 모집 종료일 */}
         <div className="pc:gap-2 flex flex-col text-sm">
           <div className="group-info-text">
-            <span className="group-info-subtitle mr-[0.5rem]">모임 장소 </span>
+            <span className="group-info-subtitle mr-[8px]">모임 장소 </span>
             {place}
           </div>
-          <div className="pc:flex-row pc:gap-[2.5rem] mt-[1.25rem] flex flex-col gap-[1.25rem]">
+          <div className="pc:flex-row pc:gap-[40px] mt-[20px] flex flex-col gap-[20px]">
             {[
               {
                 label: '모임 날짜',
@@ -103,7 +103,7 @@ export default function GroupInfoSection({
               },
             ].map(({ label, value }) => (
               <div key={label} className="group-info-text">
-                <span className="group-info-subtitle mr-[0.5rem]">{label}</span>
+                <span className="group-info-subtitle mr-[8px]">{label}</span>
                 {value}
               </div>
             ))}
@@ -113,19 +113,19 @@ export default function GroupInfoSection({
         <div className="group-info-divider-line" />
 
         {/* 모집 현황 */}
-        <div className="pc:flex-row flex flex-col gap-[1.25rem]">
+        <div className="pc:flex-row flex flex-col gap-[20px]">
           <div>
-            <p className="group-info-subtitle mb-[1.25rem]">모집 현황</p>
-            <div className="grid w-[18.813rem] grid-cols-2 gap-x-[2rem] gap-y-[0.5rem]">
+            <p className="group-info-subtitle mb-[20px]">모집 현황</p>
+            <div className="grid w-[301.008px] grid-cols-2 gap-x-[32px] gap-y-[8px]">
               {sessions.map(({ bandSession, currentCount, recruitCount }) => (
                 <div
                   key={bandSession}
-                  className="flex w-[8.875rem] items-center justify-between"
+                  className="flex w-[142px] items-center justify-between"
                 >
-                  <span className="rounded-[0.5rem] bg-[#34343a] px-[0.75rem] py-[0.375rem] text-sm text-[0.875rem] text-white">
+                  <span className="rounded-[8px] bg-[#34343a] px-[12px] py-[6px] text-sm text-[14px] text-white">
                     {SESSION_ENUM_TO_KR[bandSession]}
                   </span>
-                  <span className="group-info-text w-[2.875rem]">
+                  <span className="group-info-text w-[46px]">
                     {currentCount}/{recruitCount}
                   </span>
                 </div>
@@ -134,8 +134,8 @@ export default function GroupInfoSection({
           </div>
 
           {/* 모임 장르 */}
-          <div className="pc:w-[32.438rem] w-full">
-            <p className="group-info-subtitle mb-[1.25rem]">모임 장르</p>
+          <div className="pc:w-[519.008px] w-full">
+            <p className="group-info-subtitle mb-[20px]">모임 장르</p>
             <TagSelector
               tags={GENRE_TAGS}
               mode="readonly"
@@ -147,18 +147,20 @@ export default function GroupInfoSection({
         <div className="group-info-divider-line" />
 
         {/* 모임 소개글 */}
-        <p className="group-info-subtitle mb-[1.25rem]">모임 소개글</p>
-        <div className="group-info-text whitespace-pre-line">{description}</div>
+        <p className="group-info-subtitle mb-[20px]">모임 소개글</p>
+        <div className="group-info-text break-keep whitespace-pre-line">
+          {description}
+        </div>
       </section>
 
-      <div className="ml-[1.25rem]">
+      <div className="ml-[20px]">
         {isRecruiting && isHost && (
-          <div className="flex flex-col gap-[1.25rem]">
+          <div className="flex flex-col gap-[20px]">
             {actionButtons.map(({ label, variant, onClick }) => (
               <Button
                 key={label}
                 variant={variant as 'solid' | 'outline'}
-                className="w-[22.75rem]"
+                className="pc:w-[364px] w-full"
                 onClick={onClick}
               >
                 {label}

--- a/src/components/products/group/GroupInfoSection.tsx
+++ b/src/components/products/group/GroupInfoSection.tsx
@@ -71,7 +71,7 @@ export default function GroupInfoSection({
         {/* 모임 제목, 주최자 */}
         <div className="relative flex flex-col gap-[10px]">
           <div className="flex w-full justify-between">
-            <h1 className="group-info-title break-keep">{name}</h1>
+            <h1 className="group-info-title">{name}</h1>
           </div>
           <p className="group-info-subtitle">{creator.nickname}</p>
           <ShareIcon

--- a/src/components/products/group/MemberInfoSection.tsx
+++ b/src/components/products/group/MemberInfoSection.tsx
@@ -43,18 +43,19 @@ export default function MemberInfoSection({
 
   return (
     <>
-      <section className="flex w-[60rem] flex-col gap-[40px] rounded-[0.5rem] bg-[#202024] p-[2.5rem]">
+      <section className="pc:w-[960px] tab:p-[40px] flex w-full flex-col gap-[2.5rem] rounded-[8px] bg-[#202024] p-[20px]">
         {/* 모임 제목, 주최자 */}
-        <div className="flex h-[4.375rem] flex-col justify-between">
+        <div className="flex flex-col justify-between gap-[10px]">
           <h1 className="group-info-title">{gathering.name}</h1>
           <p className="group-info-subtitle">{gathering.creator.nickname}</p>
         </div>
 
-        <div className="border-b-[0.0625rem] border-[#2D3035]" />
+        <div className="border-b-[1px] border-[#2D3035]" />
         <MemberList
           title="확정 멤버"
           members={approvedParticipants}
           isSelectable={false}
+          gatheringId={gathering.id}
         />
         <MemberList
           title="신청 멤버"
@@ -62,15 +63,15 @@ export default function MemberInfoSection({
           selectedIds={selectedIds}
           setSelectedIds={setSelectedIds}
           isSelectable={true}
-          gathering={gathering.id}
+          gatheringId={gathering.id}
         />
       </section>
 
       {isRecruiting && (
-        <div className="ml-[1.25rem] flex flex-col gap-[1.25rem]">
+        <div className="ml-[20px] flex flex-col gap-[20px]">
           <Button
             variant="solid"
-            className="w-[22.75rem]"
+            className="pc:w-[364px] w-full"
             onClick={handleAccept}
             disabled={selectedIds.length === 0}
           >
@@ -78,7 +79,7 @@ export default function MemberInfoSection({
           </Button>
           <Button
             variant="outline"
-            className="w-[22.75rem]"
+            className="pc:w-[364px] w-full"
             onClick={handleReject}
             disabled={selectedIds.length === 0}
           >

--- a/src/components/products/group/MemberInfoSection.tsx
+++ b/src/components/products/group/MemberInfoSection.tsx
@@ -43,14 +43,14 @@ export default function MemberInfoSection({
 
   return (
     <>
-      <section className="pc:w-[960px] tab:p-[40px] flex w-full flex-col gap-[2.5rem] rounded-[8px] bg-[#202024] p-[20px]">
+      <section className="pc:w-[60rem] tab:p-[2.5rem] flex w-full flex-col gap-[40px] rounded-[0.5rem] bg-[#202024] p-[1.25rem]">
         {/* 모임 제목, 주최자 */}
-        <div className="flex flex-col justify-between gap-[10px]">
+        <div className="flex flex-col justify-between gap-[0.625rem]">
           <h1 className="group-info-title">{gathering.name}</h1>
           <p className="group-info-subtitle">{gathering.creator.nickname}</p>
         </div>
 
-        <div className="border-b-[1px] border-[#2D3035]" />
+        <div className="border-b-[0.0625rem] border-[#2D3035]" />
         <MemberList
           title="확정 멤버"
           members={approvedParticipants}
@@ -68,10 +68,10 @@ export default function MemberInfoSection({
       </section>
 
       {isRecruiting && (
-        <div className="ml-[20px] flex flex-col gap-[20px]">
+        <div className="ml-[1.25rem] flex flex-col gap-[1.25rem]">
           <Button
             variant="solid"
-            className="pc:w-[364px] w-full"
+            className="pc:w-[22.75rem] w-full"
             onClick={handleAccept}
             disabled={selectedIds.length === 0}
           >
@@ -79,7 +79,7 @@ export default function MemberInfoSection({
           </Button>
           <Button
             variant="outline"
-            className="pc:w-[364px] w-full"
+            className="pc:w-[22.75rem] w-full"
             onClick={handleReject}
             disabled={selectedIds.length === 0}
           >

--- a/src/components/products/group/MemberList.tsx
+++ b/src/components/products/group/MemberList.tsx
@@ -58,7 +58,7 @@ export default function MemberList({
 
   return (
     <div>
-      <div className="mb-[8px] text-[24px] font-bold">
+      <div className="mb-[0.5rem] text-[1.5rem] font-bold">
         {title}{' '}
         {members.length != 0 && (
           <span className="font-medium text-[#A339FF]">{members.length}</span>
@@ -72,28 +72,28 @@ export default function MemberList({
             width={128}
             height={128}
           />
-          <div className="h-[1.5rem] w-full pt-[0.5rem] text-center text-gray-400">
+          <div className="h-[24px] w-full pt-[8px] text-center text-gray-400">
             {emptyMessage}
           </div>
-          <div className="mt-[2.5rem] w-full border-b-[1px] border-[#2D3035]" />
+          <div className="mt-[40px] w-full border-b-[0.0625rem] border-[#2D3035]" />
         </div>
       ) : (
         <>
           {device === 'pc' ? (
-            <div className="flex h-[48px] items-center gap-[20px] bg-[#25252a] px-[17px] text-[15px] font-bold">
+            <div className="flex h-[3rem] items-center gap-[1.25rem] bg-[#25252a] px-[1.0625rem] text-[0.9375rem] font-bold">
               {isSelectable ? (
                 <div onClick={handleSelectAll} className="cursor-pointer">
                   {allSelected ? <Checkbox /> : <CheckboxEmpty />}
                 </div>
               ) : (
-                <div className="w-[16px]" />
+                <div className="w-[1rem]" />
               )}
-              <p className="ml-[68px] w-[139px]">닉네임</p>
-              <p className="w-[167px]">신청 세션</p>
-              <p className="w-[366px]">소개</p>
+              <p className="ml-[4.25rem] w-[8.6875rem]">닉네임</p>
+              <p className="w-[10.4375rem]">신청 세션</p>
+              <p className="w-[22.875rem]">소개</p>
             </div>
           ) : (
-            <div className="border-b-[1px] border-[#2D3035]" />
+            <div className="border-b-[0.0625rem] border-[#2D3035]" />
           )}
           {members.map((member) => (
             <MemberRow

--- a/src/components/products/group/MemberList.tsx
+++ b/src/components/products/group/MemberList.tsx
@@ -4,6 +4,7 @@ import { Participant } from '@/types/gathering';
 import Image from 'next/image';
 import CharacterImage from '../../../../public/images/img_character01.png';
 import MemberRow from './MemberRow';
+import { useDeviceType } from '@/hooks/useDeviceType';
 
 interface MemberListProps {
   title: string;
@@ -11,7 +12,7 @@ interface MemberListProps {
   isSelectable?: boolean;
   selectedIds?: number[];
   setSelectedIds?: React.Dispatch<React.SetStateAction<number[]>>;
-  gathering?: number;
+  gatheringId?: number;
 }
 
 export default function MemberList({
@@ -20,8 +21,9 @@ export default function MemberList({
   isSelectable = true,
   selectedIds = [],
   setSelectedIds,
-  gathering,
+  gatheringId: gatheringId,
 }: MemberListProps) {
+  const device = useDeviceType();
   const handleSelectChange = (id: number) => {
     if (!isSelectable || !setSelectedIds) {
       return;
@@ -56,7 +58,7 @@ export default function MemberList({
 
   return (
     <div>
-      <div className="mb-[0.5rem] text-[1.5rem] font-bold">
+      <div className="mb-[8px] text-[24px] font-bold">
         {title}{' '}
         {members.length != 0 && (
           <span className="font-medium text-[#A339FF]">{members.length}</span>
@@ -66,29 +68,33 @@ export default function MemberList({
         <div className="flex w-full flex-col items-center justify-center">
           <Image
             src={CharacterImage}
-            alt="링크 공유 캐릭터 이미지"
+            alt="캐릭터 이미지"
             width={128}
             height={128}
           />
-          <div className="h-[24px] w-full pt-[8px] text-center text-gray-400">
+          <div className="h-[1.5rem] w-full pt-[0.5rem] text-center text-gray-400">
             {emptyMessage}
           </div>
-          <div className="mt-[40px] w-full border-b-[0.0625rem] border-[#2D3035]" />
+          <div className="mt-[2.5rem] w-full border-b-[1px] border-[#2D3035]" />
         </div>
       ) : (
         <>
-          <div className="flex h-[3rem] items-center gap-[1.25rem] bg-[#25252a] px-[1.0625rem] text-[0.9375rem] font-bold">
-            {isSelectable ? (
-              <div onClick={handleSelectAll} className="cursor-pointer">
-                {allSelected ? <Checkbox /> : <CheckboxEmpty />}
-              </div>
-            ) : (
-              <div className="w-[1rem]" />
-            )}
-            <p className="ml-[4.25rem] w-[8.6875rem]">닉네임</p>
-            <p className="w-[10.4375rem]">신청 세션</p>
-            <p className="w-[22.875rem]">소개</p>
-          </div>
+          {device === 'pc' ? (
+            <div className="flex h-[48px] items-center gap-[20px] bg-[#25252a] px-[17px] text-[15px] font-bold">
+              {isSelectable ? (
+                <div onClick={handleSelectAll} className="cursor-pointer">
+                  {allSelected ? <Checkbox /> : <CheckboxEmpty />}
+                </div>
+              ) : (
+                <div className="w-[16px]" />
+              )}
+              <p className="ml-[68px] w-[139px]">닉네임</p>
+              <p className="w-[167px]">신청 세션</p>
+              <p className="w-[366px]">소개</p>
+            </div>
+          ) : (
+            <div className="border-b-[1px] border-[#2D3035]" />
+          )}
           {members.map((member) => (
             <MemberRow
               key={`${member.userId}-${member.bandSession}`}
@@ -100,7 +106,7 @@ export default function MemberList({
               selected={selectedIds.includes(member.participantId)}
               onSelectChange={handleSelectChange}
               isSelectable={isSelectable}
-              gathering={gathering}
+              gatheringId={gatheringId}
             />
           ))}
         </>

--- a/src/components/products/group/MemberRow.tsx
+++ b/src/components/products/group/MemberRow.tsx
@@ -29,39 +29,39 @@ export default function MemberRow({
 }: MemberRowProps) {
   return (
     <div>
-      <div className="my-[12px] flex items-center gap-[20px] px-[17px]">
+      <div className="my-[0.75rem] flex items-center gap-[1.25rem] px-[1.0625rem]">
         {isSelectable ? (
           <div onClick={() => onSelectChange(id)} className="cursor-pointer">
             {selected ? <Checkbox /> : <CheckboxEmpty />}
           </div>
         ) : (
-          <div className="w-[16px]" />
+          <div className="w-[1rem]" />
         )}
 
         <div className="pc:flex-row flex w-full flex-col">
-          <div className="tab:gap-[20px] mr-[20px] flex items-center gap-[12px]">
+          <div className="tab:gap-[1.25rem] mr-[1.25rem] flex items-center gap-[0.75rem]">
             <ProfileImage src={profileImage} size={3} />
 
-            <div className="pc:w-[139px] underline underline-offset-2">
+            <div className="pc:w-[8.6875rem] underline underline-offset-2">
               <Link href={`/group/${gatheringId}/reviews/${id}`}>
                 {nickname}
               </Link>
             </div>
 
-            <div className="pc:w-[167px] flex gap-[4px]">
-              <div className="rounded-[8px] bg-[#34343A] px-[12px] py-[6px] text-gray-100">
+            <div className="pc:w-[10.4375rem] flex gap-[0.25rem]">
+              <div className="rounded-[0.5rem] bg-[#34343A] px-[0.75rem] py-[0.375rem] text-gray-100">
                 {SESSION_ENUM_TO_KR[session]}
               </div>
             </div>
           </div>
 
-          <div className="pc:w-[366px] pc:mt-0 mt-[12px] break-keep whitespace-pre-line">
+          <div className="pc:w-[22.875rem] pc:mt-0 mt-[0.75rem] break-keep whitespace-pre-line">
             {introduction}
           </div>
         </div>
       </div>
 
-      <div className="border-b-[1px] border-[#2D3035]" />
+      <div className="border-b-[0.0625rem] border-[#2D3035]" />
     </div>
   );
 }

--- a/src/components/products/group/MemberRow.tsx
+++ b/src/components/products/group/MemberRow.tsx
@@ -13,7 +13,7 @@ interface MemberRowProps {
   introduction: string;
   profileImage?: string | null;
   isSelectable?: boolean;
-  gathering?: number;
+  gatheringId?: number;
 }
 
 export default function MemberRow({
@@ -25,37 +25,43 @@ export default function MemberRow({
   introduction,
   profileImage = null,
   isSelectable = true,
-  gathering,
+  gatheringId: gatheringId,
 }: MemberRowProps) {
   return (
     <div>
-      <div className="my-[0.75rem] flex items-center gap-[1.25rem] px-[1.0625rem]">
+      <div className="my-[12px] flex items-center gap-[20px] px-[17px]">
         {isSelectable ? (
           <div onClick={() => onSelectChange(id)} className="cursor-pointer">
             {selected ? <Checkbox /> : <CheckboxEmpty />}
           </div>
         ) : (
-          <div className="w-[1rem]" />
+          <div className="w-[16px]" />
         )}
-        <ProfileImage src={profileImage} size={3} />
 
-        <div className="w-[8.6875rem] underline underline-offset-2">
-          {!gathering && nickname}
-          {gathering && (
-            <Link href={`/group/${gathering}/reviews/${id}`}>{nickname}</Link>
-          )}
-        </div>
+        <div className="pc:flex-row flex w-full flex-col">
+          <div className="tab:gap-[20px] mr-[20px] flex items-center gap-[12px]">
+            <ProfileImage src={profileImage} size={3} />
 
-        <div className="flex w-[10.4375rem] gap-[0.25rem]">
-          <div className="rounded-[0.5rem] bg-[#34343A] px-[0.75rem] py-[0.375rem] text-gray-100">
-            {SESSION_ENUM_TO_KR[session]}
+            <div className="pc:w-[139px] underline underline-offset-2">
+              <Link href={`/group/${gatheringId}/reviews/${id}`}>
+                {nickname}
+              </Link>
+            </div>
+
+            <div className="pc:w-[167px] flex gap-[4px]">
+              <div className="rounded-[8px] bg-[#34343A] px-[12px] py-[6px] text-gray-100">
+                {SESSION_ENUM_TO_KR[session]}
+              </div>
+            </div>
+          </div>
+
+          <div className="pc:w-[366px] pc:mt-0 mt-[12px] break-keep whitespace-pre-line">
+            {introduction}
           </div>
         </div>
-        <div className="line-clamp-2 w-[22.875rem] overflow-hidden text-ellipsis">
-          {introduction}
-        </div>
       </div>
-      <div className="border-b-[0.0625rem] border-[#2D3035]" />
+
+      <div className="border-b-[1px] border-[#2D3035]" />
     </div>
   );
 }

--- a/src/components/products/group/ParticipantsSection.tsx
+++ b/src/components/products/group/ParticipantsSection.tsx
@@ -97,8 +97,8 @@ export default function ParticipantsSection({
   };
 
   return (
-    <section className="pc:w-[960px] tab:p-[40px] w-full rounded-[8px] bg-[#202024] p-[20px]">
-      <div className="flex flex-col justify-between gap-[10px]">
+    <section className="pc:w-[60rem] tab:p-[2.5rem] w-full rounded-[0.5rem] bg-[#202024] p-[1.25rem]">
+      <div className="flex flex-col justify-between gap-[0.625rem]">
         <h1 className="group-info-title">{gathering.name}</h1>
         <p className="group-info-subtitle">{gathering.creator.nickname}</p>
       </div>
@@ -125,24 +125,24 @@ export default function ParticipantsSection({
 
           return (
             <div key={participantId}>
-              <div className="pc:flex-row pc:items-center my-[12px] flex flex-col">
-                <div className="tab:gap-[20px] mr-[20px] flex items-center gap-[12px]">
+              <div className="pc:flex-row pc:items-center my-[0.75rem] flex flex-col">
+                <div className="tab:gap-[1.25rem] mr-[1.25rem] flex items-center gap-[0.75rem]">
                   <ProfileImage src={profileImagePath} size={3} />
 
-                  <div className="pc:w-[139px] flex items-center">
-                    <span className="text-[16px] underline underline-offset-2">
+                  <div className="pc:w-[8.6875rem] flex items-center">
+                    <span className="text-[1rem] underline underline-offset-2">
                       {userNickname}
                     </span>
                     {isHostItem && (
-                      <div className="ml-[7px] flex h-[16px] w-[46px] items-center justify-center rounded-[8.5008px] bg-purple-700 text-center text-[12px] font-semibold">
+                      <div className="ml-[0.4375rem] flex h-[1rem] w-[2.875rem] items-center justify-center rounded-[0.5313rem] bg-purple-700 text-center text-[0.75rem] font-semibold">
                         주최자
                       </div>
                     )}
                   </div>
 
-                  <div className="pc:w-[167px] flex gap-[4px]">
+                  <div className="pc:w-[10.4375rem] flex gap-[0.25rem]">
                     {!isHostItem && (
-                      <div className="rounded-[8px] bg-[#34343A] px-[12px] py-[6px] text-gray-100">
+                      <div className="rounded-[0.5rem] bg-[#34343A] px-[0.75rem] py-[0.375rem] text-gray-100">
                         {SESSION_ENUM_TO_KR[bandSession]}
                       </div>
                     )}
@@ -151,8 +151,8 @@ export default function ParticipantsSection({
 
                 <div
                   className={clsx(
-                    'pc:mt-0 mt-[12px] flex items-center break-keep text-ellipsis whitespace-pre-line',
-                    isCompleted ? 'pc:w-[326px]' : 'pc:w-[470px]',
+                    'pc:mt-0 mt-[0.75rem] flex items-center break-keep text-ellipsis whitespace-pre-line',
+                    isCompleted ? 'pc:w-[20.375rem]' : 'pc:w-[29.375rem]',
                   )}
                 >
                   {introduction}
@@ -161,18 +161,18 @@ export default function ParticipantsSection({
                 {isCompleted &&
                   user?.id !== userId &&
                   (isParticipating || isHost) && (
-                    <div className="pc:mt-0 mt-[12px]">
+                    <div className="pc:mt-0 mt-[0.75rem]">
                       {hasWrittenReview ? (
                         <Button
                           disabled
                           variant="outline"
-                          className="pc:w-[7.75rem] w-full"
+                          className="pc:w-[124px] w-full"
                         >
                           리뷰 작성 완료
                         </Button>
                       ) : (
                         <Button
-                          className="pc:w-[7.75rem] w-full"
+                          className="pc:w-[124px] w-full"
                           variant="outline"
                           onClick={() =>
                             handleOpenReviewModal(userId, userNickname)
@@ -184,20 +184,20 @@ export default function ParticipantsSection({
                     </div>
                   )}
               </div>
-              <div className="border-b-[1px] border-[#2D3035]" />
+              <div className="border-b-[0.0625rem] border-[#2D3035]" />
             </div>
           );
         },
       )}
       {participants.length === 0 && (
-        <div className="mt-[40px] flex w-full flex-col items-center justify-center">
+        <div className="mt-[2.5rem] flex w-full flex-col items-center justify-center">
           <Image
             src="/images/img_character01.png"
             alt="링크 공유 캐릭터 이미지"
             width={128}
             height={128}
           />
-          <div className="h-[24px] w-full pt-[8px] text-center text-gray-400">
+          <div className="h-[1.5rem] w-full pt-[0.5rem] text-center text-gray-400">
             아직 참여 멤버가 없어요~
           </div>
         </div>

--- a/src/components/products/group/ParticipantsSection.tsx
+++ b/src/components/products/group/ParticipantsSection.tsx
@@ -97,8 +97,8 @@ export default function ParticipantsSection({
   };
 
   return (
-    <section className="w-[60rem] rounded-[0.5rem] bg-[#202024] p-[2.5rem]">
-      <div className="flex h-[4.375rem] flex-col justify-between">
+    <section className="pc:w-[960px] tab:p-[40px] w-full rounded-[8px] bg-[#202024] p-[20px]">
+      <div className="flex flex-col justify-between gap-[10px]">
         <h1 className="group-info-title">{gathering.name}</h1>
         <p className="group-info-subtitle">{gathering.creator.nickname}</p>
       </div>
@@ -125,32 +125,34 @@ export default function ParticipantsSection({
 
           return (
             <div key={participantId}>
-              <div className="my-[0.75rem] flex items-center gap-[1.25rem]">
-                <ProfileImage src={profileImagePath} size={3} />
+              <div className="pc:flex-row pc:items-center my-[12px] flex flex-col">
+                <div className="tab:gap-[20px] mr-[20px] flex items-center gap-[12px]">
+                  <ProfileImage src={profileImagePath} size={3} />
 
-                <div className="flex w-[8.6875rem] items-center">
-                  <span className="text-[1rem] underline underline-offset-2">
-                    {userNickname}
-                  </span>
-                  {isHostItem && (
-                    <div className="ml-[0.4375rem] flex h-[1rem] w-[2.875rem] items-center justify-center rounded-[0.5313rem] bg-purple-700 text-center text-[0.75rem] font-semibold">
-                      주최자
-                    </div>
-                  )}
-                </div>
+                  <div className="pc:w-[139px] flex items-center">
+                    <span className="text-[16px] underline underline-offset-2">
+                      {userNickname}
+                    </span>
+                    {isHostItem && (
+                      <div className="ml-[7px] flex h-[16px] w-[46px] items-center justify-center rounded-[8.5008px] bg-purple-700 text-center text-[12px] font-semibold">
+                        주최자
+                      </div>
+                    )}
+                  </div>
 
-                <div className="flex w-[10.4375rem] gap-[0.25rem]">
-                  {!isHostItem && (
-                    <div className="rounded-[0.5rem] bg-[#34343A] px-[0.75rem] py-[0.375rem] text-gray-100">
-                      {SESSION_ENUM_TO_KR[bandSession]}
-                    </div>
-                  )}
+                  <div className="pc:w-[167px] flex gap-[4px]">
+                    {!isHostItem && (
+                      <div className="rounded-[8px] bg-[#34343A] px-[12px] py-[6px] text-gray-100">
+                        {SESSION_ENUM_TO_KR[bandSession]}
+                      </div>
+                    )}
+                  </div>
                 </div>
 
                 <div
                   className={clsx(
-                    'line-clamp-2 overflow-hidden text-ellipsis',
-                    isCompleted ? 'w-[20.375rem]' : 'w-[29.375rem]',
+                    'pc:mt-0 mt-[12px] flex items-center break-keep text-ellipsis whitespace-pre-line',
+                    isCompleted ? 'pc:w-[326px]' : 'pc:w-[470px]',
                   )}
                 >
                   {introduction}
@@ -158,36 +160,44 @@ export default function ParticipantsSection({
 
                 {isCompleted &&
                   user?.id !== userId &&
-                  (isParticipating || isHost) &&
-                  (hasWrittenReview ? (
-                    <Button disabled className="w-[124px]">
-                      리뷰 작성 완료
-                    </Button>
-                  ) : (
-                    <Button
-                      className="w-[124px]"
-                      onClick={() =>
-                        handleOpenReviewModal(userId, userNickname)
-                      }
-                    >
-                      리뷰 쓰기
-                    </Button>
-                  ))}
+                  (isParticipating || isHost) && (
+                    <div className="pc:mt-0 mt-[12px]">
+                      {hasWrittenReview ? (
+                        <Button
+                          disabled
+                          variant="outline"
+                          className="pc:w-[7.75rem] w-full"
+                        >
+                          리뷰 작성 완료
+                        </Button>
+                      ) : (
+                        <Button
+                          className="pc:w-[7.75rem] w-full"
+                          variant="outline"
+                          onClick={() =>
+                            handleOpenReviewModal(userId, userNickname)
+                          }
+                        >
+                          리뷰 쓰기
+                        </Button>
+                      )}
+                    </div>
+                  )}
               </div>
-              <div className="border-b-[0.0625rem] border-[#2D3035]" />
+              <div className="border-b-[1px] border-[#2D3035]" />
             </div>
           );
         },
       )}
       {participants.length === 0 && (
-        <div className="mt-[2.5rem] flex w-full flex-col items-center justify-center">
+        <div className="mt-[40px] flex w-full flex-col items-center justify-center">
           <Image
             src="/images/img_character01.png"
             alt="링크 공유 캐릭터 이미지"
             width={128}
             height={128}
           />
-          <div className="h-[1.5rem] w-full pt-[0.5rem] text-center text-gray-400">
+          <div className="h-[24px] w-full pt-[8px] text-center text-gray-400">
             아직 참여 멤버가 없어요~
           </div>
         </div>

--- a/src/styles/utililtes.css
+++ b/src/styles/utililtes.css
@@ -3,7 +3,7 @@
 /* 그룹 상세 커스텀 스타일 */
 @layer utilities {
   .group-info-title {
-    @apply text-[1.5rem] font-bold text-gray-100;
+    @apply text-[1.5rem] font-bold break-keep text-gray-100;
   }
   .group-info-subtitle {
     @apply text-[1rem] text-gray-400;


### PR DESCRIPTION
## 연관된 이슈

close #171

## 작업내용
- 모집글 반응형 수정
- 참여멤버 반응형 적용

## 스크린샷
### 참여자 승인, 거절 화면
<img width="1102" alt="스크린샷 2025-06-19 오후 4 11 37" src="https://github.com/user-attachments/assets/eca0b35a-94b3-4ff5-9f0c-b8c290cb2cc2" />

### 리뷰 작성 화면
<img width="1037" alt="스크린샷 2025-06-19 오후 5 05 22" src="https://github.com/user-attachments/assets/350a0eb5-7e0e-468c-99a9-85b6b188e40b" />

### 모집글 화면
![image](https://github.com/user-attachments/assets/51f3d2f7-93d4-4f04-9fe0-a46a652aee62)

