### PR TITLE
[추가기능] 이메일 인증 

### DIFF
--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -43,6 +43,8 @@ interface InputProps {
   isrightbutton?: boolean;
   /** 버튼 내용 */
   children?: ReactNode;
+  /** 오른쪽 버튼 클릭 이벤트 */
+  onRightButtonClick?: () => void;
 }
 
 function Input({
@@ -61,6 +63,7 @@ function Input({
   size,
   isrightbutton,
   children,
+  onRightButtonClick,
 }: InputProps) {
   const {
     register,
@@ -150,7 +153,7 @@ function Input({
                 type="button"
                 variant="outline"
                 className="w-auto max-w-[6.8125rem] min-w-[5.8125rem]"
-                onClick={() => alert('버튼입력')}
+                onClick={onRightButtonClick}
               >
                 {children}
               </Button>

--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -41,10 +41,12 @@ interface InputProps {
   size?: 'xs' | 'sm' | 'md' | 'lg';
   /** 오른쪽 버튼 표시 여부 */
   isrightbutton?: boolean;
-  /** 버튼 내용 */
-  children?: ReactNode;
+  /** 오른쪽 버튼 비활성화 */
+  rightButtonDisabled?: boolean;
   /** 오른쪽 버튼 클릭 이벤트 */
   onRightButtonClick?: () => void;
+  /** 버튼 내용 */
+  children?: ReactNode;
 }
 
 function Input({
@@ -62,17 +64,20 @@ function Input({
   innerRef,
   size,
   isrightbutton,
-  children,
+  rightButtonDisabled,
   onRightButtonClick,
+  children,
 }: InputProps) {
   const {
     register,
     setValue,
     formState: { errors },
   } = useFormContext();
+
   const IsError = errors[name];
   const IsPwd = type === 'password';
   const [showPassword, setShowPassword] = useState(false);
+
   const sizeClass = {
     // 283px
     xs: 'tab:w-[17.6875rem] w-[13.125rem]',
@@ -154,6 +159,7 @@ function Input({
                 variant="outline"
                 className="w-auto max-w-[6.8125rem] min-w-[5.8125rem]"
                 onClick={onRightButtonClick}
+                disabled={rightButtonDisabled}
               >
                 {children}
               </Button>

--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -37,7 +37,7 @@ interface InputProps {
   /** register에서 받은 ref */
   innerRef?: RefObject<HTMLInputElement | null>;
   /** input의 너비 */
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
 }
 
 function Input({
@@ -64,8 +64,10 @@ function Input({
   const IsPwd = type === 'password';
   const [showPassword, setShowPassword] = useState(false);
   const sizeClass = {
+    // 283px
+    xs: 'tab:w-[17.6875rem] w-[13.125rem]',
     // 400px
-    sm: 'w-[25rem]',
+    sm: 'pc:w-[25rem] w-[19.4375rem]',
     // 448px
     md: 'w-[28rem]',
     lg: 'w-auto',
@@ -105,54 +107,59 @@ function Input({
   });
 
   return (
-    <div className="flex flex-col gap-[0.5rem]">
-      <label
-        htmlFor={name}
-        className="block text-sm font-semibold text-gray-100"
-      >
-        {label}
-      </label>
-      <div className={`relative ${sizeClass} text-gray-400`}>
-        <input
-          id={name}
-          type={IsPwd ? (showPassword ? 'text' : 'password') : type}
-          onFocus={onInputFocus}
-          placeholder={placeholder}
-          defaultValue={defaultValue}
-          minLength={minLength}
-          maxLength={maxLength}
-          ref={(el) => {
-            ref(el);
-            if (innerRef) {
-              innerRef.current = el;
-            }
-          }}
-          {...rest}
-          className={`h-[2.75rem] w-full rounded-lg border-0 bg-[#34343A] px-[1rem] py-[0.625rem] ${
-            IsError
-              ? 'border-red-500 focus-within:border-red-500 focus-within:ring-red-500'
-              : 'focus-within:ring-0 focus-within:outline-none'
-          }`}
+    <>
+      <div className="flex flex-col gap-[0.5rem]">
+        <label
+          htmlFor={name}
+          className="block text-sm font-semibold text-gray-100"
+        >
+          {label}
+        </label>
+        <div className={`relative ${sizeClass} text-gray-400`}>
+          <input
+            id={name}
+            type={IsPwd ? (showPassword ? 'text' : 'password') : type}
+            onFocus={onInputFocus}
+            placeholder={placeholder}
+            defaultValue={defaultValue}
+            minLength={minLength}
+            maxLength={maxLength}
+            ref={(el) => {
+              ref(el);
+              if (innerRef) {
+                innerRef.current = el;
+              }
+            }}
+            {...rest}
+            className={`h-[2.75rem] w-full rounded-lg border-0 bg-[#34343A] px-[1rem] py-[0.625rem] ${
+              IsError
+                ? 'border-red-500 focus-within:border-red-500 focus-within:ring-red-500'
+                : 'focus-within:ring-0 focus-within:outline-none'
+            }`}
+          />
+          {IsPwd && (
+            <button
+              type="button"
+              onClick={() => setShowPassword((prev) => !prev)}
+              className="absolute top-1/2 right-3 -translate-y-1/2"
+              aria-label="비밀번호 숨김 버튼"
+            >
+              {showPassword ? <Visibility /> : <Invisibility />}
+            </button>
+          )}
+        </div>
+        <ErrorMessage
+          errors={errors}
+          name={name}
+          render={({ message }) => (
+            <p className="mt-1 text-sm text-red-500">{message}</p>
+          )}
         />
-        {IsPwd && (
-          <button
-            type="button"
-            onClick={() => setShowPassword((prev) => !prev)}
-            className="absolute top-1/2 right-3 -translate-y-1/2"
-            aria-label="비밀번호 숨김 버튼"
-          >
-            {showPassword ? <Visibility /> : <Invisibility />}
-          </button>
+        {!IsError && (
+          <div className="mt-1 text-sm text-transparent">placeholder</div>
         )}
       </div>
-      <ErrorMessage
-        errors={errors}
-        name={name}
-        render={({ message }) => (
-          <p className="mt-1 text-sm text-red-500">{message}</p>
-        )}
-      />
-    </div>
+    </>
   );
 }
 

--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -12,6 +12,7 @@ import React, {
   useState,
 } from 'react';
 import { RegisterOptions, useFormContext } from 'react-hook-form';
+import Button from './Button';
 
 interface InputProps {
   /** RHF name속성 */
@@ -38,6 +39,10 @@ interface InputProps {
   innerRef?: RefObject<HTMLInputElement | null>;
   /** input의 너비 */
   size?: 'xs' | 'sm' | 'md' | 'lg';
+  /** 오른쪽 버튼 표시 여부 */
+  isrightbutton?: boolean;
+  /** 버튼 내용 */
+  children?: ReactNode;
 }
 
 function Input({
@@ -54,6 +59,8 @@ function Input({
   defaultValue,
   innerRef,
   size,
+  isrightbutton,
+  children,
 }: InputProps) {
   const {
     register,
@@ -116,27 +123,39 @@ function Input({
           {label}
         </label>
         <div className={`relative ${sizeClass} text-gray-400`}>
-          <input
-            id={name}
-            type={IsPwd ? (showPassword ? 'text' : 'password') : type}
-            onFocus={onInputFocus}
-            placeholder={placeholder}
-            defaultValue={defaultValue}
-            minLength={minLength}
-            maxLength={maxLength}
-            ref={(el) => {
-              ref(el);
-              if (innerRef) {
-                innerRef.current = el;
-              }
-            }}
-            {...rest}
-            className={`h-[2.75rem] w-full rounded-lg border-0 bg-[#34343A] px-[1rem] py-[0.625rem] ${
-              IsError
-                ? 'border-red-500 focus-within:border-red-500 focus-within:ring-red-500'
-                : 'focus-within:ring-0 focus-within:outline-none'
-            }`}
-          />
+          <div className="flex flex-row items-center gap-[0.5rem]">
+            <input
+              id={name}
+              type={IsPwd ? (showPassword ? 'text' : 'password') : type}
+              onFocus={onInputFocus}
+              placeholder={placeholder}
+              defaultValue={defaultValue}
+              minLength={minLength}
+              maxLength={maxLength}
+              ref={(el) => {
+                ref(el);
+                if (innerRef) {
+                  innerRef.current = el;
+                }
+              }}
+              {...rest}
+              className={`h-[2.75rem] w-full rounded-lg border-0 bg-[#34343A] px-[1rem] py-[0.625rem] ${
+                IsError
+                  ? 'border-red-500 focus-within:border-red-500 focus-within:ring-red-500'
+                  : 'focus-within:ring-0 focus-within:outline-none'
+              }`}
+            />
+            {isrightbutton && (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-auto max-w-[6.8125rem] min-w-[5.8125rem]"
+                onClick={() => alert('버튼입력')}
+              >
+                {children}
+              </Button>
+            )}
+          </div>
           {IsPwd && (
             <button
               type="button"
@@ -155,9 +174,6 @@ function Input({
             <p className="mt-1 text-sm text-red-500">{message}</p>
           )}
         />
-        {!IsError && (
-          <div className="mt-1 text-sm text-transparent">placeholder</div>
-        )}
       </div>
     </>
   );

--- a/src/components/products/signup/step1/SignupStep1Page.tsx
+++ b/src/components/products/signup/step1/SignupStep1Page.tsx
@@ -30,8 +30,9 @@ export default function SignUpStep1Page() {
     defaultValues: { email: '', name: '', password: '' },
     shouldUnregister: false,
   });
+
   const {
-    formState: { isValid },
+    formState: { isValid, isSubmitting, errors },
     watch,
     setError,
     clearErrors,
@@ -39,11 +40,15 @@ export default function SignUpStep1Page() {
 
   const email = useWatch({ name: 'email', control: methods.control });
   const password = watch('password');
+  const name = watch('name');
+
   const [checking, setChecking] = useState(false);
   const [isDuplicate, setIsDuplicate] = useState<boolean | null>(null);
   const [duplicateMessage, setDuplicateMessage] = useState<string | null>(null);
+
   const isValidEmailFormat = (email: string) =>
     /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
   const checkEmail = useCallback(async (emailToCheck: string) => {
     setChecking(true);
     try {
@@ -62,6 +67,7 @@ export default function SignUpStep1Page() {
       setChecking(false);
     }
   }, []);
+
   const debounceCheckEmail = useMemo(
     () => debounce(checkEmail, 500),
     [checkEmail],
@@ -105,6 +111,15 @@ export default function SignUpStep1Page() {
     alert('이메일 확인 버튼이 클릭되었습니다.');
   };
 
+  const isEmailButtonDisabled =
+    !email ||
+    !!errors.email ||
+    isSubmitting ||
+    checking ||
+    Boolean(isDuplicate);
+
+  const isCodeButtonDisabled = !name || !!errors.name || isSubmitting;
+
   return (
     <AuthCard title="회원가입" linkTo="login">
       <div className="tab:w-[25.125rem] flex w-[19.4375rem] flex-col items-center">
@@ -123,6 +138,7 @@ export default function SignUpStep1Page() {
                   size="lg"
                   placeholder="이메일을 입력해주세요."
                   isrightbutton={true}
+                  rightButtonDisabled={isEmailButtonDisabled}
                   onRightButtonClick={handleEmailSendClick}
                   rules={{
                     required: '이메일은 필수 입력입니다.',
@@ -152,6 +168,7 @@ export default function SignUpStep1Page() {
                 size="lg"
                 placeholder="인증 6자리를 입력해주세요."
                 isrightbutton={true}
+                rightButtonDisabled={isCodeButtonDisabled}
                 onRightButtonClick={handleEmailVerifyClick}
                 rules={{
                   required: '인증번호는 필수 입력입니다.',

--- a/src/components/products/signup/step1/SignupStep1Page.tsx
+++ b/src/components/products/signup/step1/SignupStep1Page.tsx
@@ -97,12 +97,13 @@ export default function SignUpStep1Page() {
             noValidate
             className="w-full"
           >
-            <div className="flex flex-col gap-[1.5rem]">
-              <div>
+            <div className="flex flex-col gap-[0.75rem]">
+              <div className="flex flex-row items-center gap-[0.5rem]">
                 <Input
                   name="email"
                   type="text"
                   label="아이디"
+                  size="xs"
                   placeholder="이메일을 입력해주세요."
                   rules={{
                     required: '이메일은 필수 입력입니다.',
@@ -112,6 +113,13 @@ export default function SignUpStep1Page() {
                     },
                   }}
                 />
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="tab:w-[6.8125rem] w-[5.8125rem]"
+                >
+                  인증하기
+                </Button>
                 {duplicateMessage && (
                   <p
                     className={`mt-3 text-sm ${
@@ -122,15 +130,25 @@ export default function SignUpStep1Page() {
                   </p>
                 )}
               </div>
-              <Input
-                name="name"
-                type="text"
-                label="이름"
-                placeholder="이름을 입력해주세요."
-                rules={{
-                  required: '이름은 필수 입력입니다.',
-                }}
-              />
+              <div className="flex flex-row items-center gap-[0.5rem]">
+                <Input
+                  name="name"
+                  type="text"
+                  label="인증번호 입력"
+                  size="xs"
+                  placeholder="인증 6자리를 입력해주세요."
+                  rules={{
+                    required: '인증번호는 필수 입력입니다.',
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="tab:w-[6.8125rem] w-[5.8125rem]"
+                >
+                  인증확인
+                </Button>
+              </div>
               <Input
                 name="password"
                 type="password"

--- a/src/components/products/signup/step1/SignupStep1Page.tsx
+++ b/src/components/products/signup/step1/SignupStep1Page.tsx
@@ -15,7 +15,7 @@ import {
   useWatch,
 } from 'react-hook-form';
 import { useSendCodeMutation } from '@/hooks/queries/auth/useSendCodeMutation';
-import { useToastStore } from '@/stores/useToastStore';
+import { useVerifyCodeMutation } from '@/hooks/queries/auth/useVerifyCodeMutation';
 
 interface FormValues {
   email: string;
@@ -39,8 +39,8 @@ export default function SignUpStep1Page() {
   } = methods;
 
   const email = useWatch({ name: 'email', control: methods.control });
+  const code = useWatch({ name: 'name', control: methods.control });
   const password = watch('password');
-  const name = watch('name');
 
   const [checking, setChecking] = useState(false);
   const [isDuplicate, setIsDuplicate] = useState<boolean | null>(null);
@@ -74,7 +74,7 @@ export default function SignUpStep1Page() {
   );
 
   const sendCodeMutation = useSendCodeMutation();
-  const showToast = useToastStore((state) => state.show);
+  const verifyCodeMutation = useVerifyCodeMutation();
 
   useEffect(() => {
     if (!email) {
@@ -100,15 +100,11 @@ export default function SignUpStep1Page() {
   };
 
   const handleEmailSendClick = () => {
-    if (!email) {
-      showToast('이메일을 입력해주세요.');
-      return;
-    }
     sendCodeMutation.mutate({ email });
   };
 
   const handleEmailVerifyClick = () => {
-    alert('이메일 확인 버튼이 클릭되었습니다.');
+    verifyCodeMutation.mutate({ email, code });
   };
 
   const isSendButtonDisabled =
@@ -119,7 +115,7 @@ export default function SignUpStep1Page() {
     Boolean(isDuplicate) ||
     sendCodeMutation.isPending;
 
-  const isVerifyButtonDisabled = !name || !!errors.name || isSubmitting;
+  const isVerifyButtonDisabled = !code || !!errors.name || isSubmitting;
 
   return (
     <AuthCard title="회원가입" linkTo="login">

--- a/src/components/products/signup/step1/SignupStep1Page.tsx
+++ b/src/components/products/signup/step1/SignupStep1Page.tsx
@@ -14,6 +14,8 @@ import {
   useForm,
   useWatch,
 } from 'react-hook-form';
+import { useSendCodeMutation } from '@/hooks/queries/auth/useSendCodeMutation';
+import { useToastStore } from '@/stores/useToastStore';
 
 interface FormValues {
   email: string;
@@ -65,6 +67,9 @@ export default function SignUpStep1Page() {
     [checkEmail],
   );
 
+  const sendCodeMutation = useSendCodeMutation();
+  const showToast = useToastStore((state) => state.show);
+
   useEffect(() => {
     if (!email) {
       setDuplicateMessage(null);
@@ -88,6 +93,18 @@ export default function SignUpStep1Page() {
     router.push('/signup/step2');
   };
 
+  const handleEmailSendClick = () => {
+    if (!email) {
+      showToast('이메일을 입력해주세요.');
+      return;
+    }
+    sendCodeMutation.mutate({ email });
+  };
+
+  const handleEmailVerifyClick = () => {
+    alert('이메일 확인 버튼이 클릭되었습니다.');
+  };
+
   return (
     <AuthCard title="회원가입" linkTo="login">
       <div className="tab:w-[25.125rem] flex w-[19.4375rem] flex-col items-center">
@@ -98,32 +115,35 @@ export default function SignUpStep1Page() {
             className="w-full"
           >
             <div className="flex flex-col gap-[1.5rem]">
-              <Input
-                name="email"
-                type="text"
-                label="아이디"
-                size="lg"
-                placeholder="이메일을 입력해주세요."
-                isrightbutton={true}
-                rules={{
-                  required: '이메일은 필수 입력입니다.',
-                  pattern: {
-                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-                    message: '올바른 이메일 형식을 입력해주세요.',
-                  },
-                }}
-              >
-                인증하기
-              </Input>
-              {duplicateMessage && (
-                <p
-                  className={`mt-3 text-sm ${
-                    isDuplicate ? 'text-red-500' : 'text-[#bf5eff]'
-                  }`}
+              <div>
+                <Input
+                  name="email"
+                  type="text"
+                  label="아이디"
+                  size="lg"
+                  placeholder="이메일을 입력해주세요."
+                  isrightbutton={true}
+                  onRightButtonClick={handleEmailSendClick}
+                  rules={{
+                    required: '이메일은 필수 입력입니다.',
+                    pattern: {
+                      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                      message: '올바른 이메일 형식을 입력해주세요.',
+                    },
+                  }}
                 >
-                  {duplicateMessage}
-                </p>
-              )}
+                  인증하기
+                </Input>
+                {duplicateMessage && (
+                  <p
+                    className={`mt-3 text-sm ${
+                      isDuplicate ? 'text-red-500' : 'text-[#bf5eff]'
+                    }`}
+                  >
+                    {duplicateMessage}
+                  </p>
+                )}
+              </div>
 
               <Input
                 name="name"
@@ -132,6 +152,7 @@ export default function SignUpStep1Page() {
                 size="lg"
                 placeholder="인증 6자리를 입력해주세요."
                 isrightbutton={true}
+                onRightButtonClick={handleEmailVerifyClick}
                 rules={{
                   required: '인증번호는 필수 입력입니다.',
                 }}

--- a/src/components/products/signup/step1/SignupStep1Page.tsx
+++ b/src/components/products/signup/step1/SignupStep1Page.tsx
@@ -111,14 +111,15 @@ export default function SignUpStep1Page() {
     alert('이메일 확인 버튼이 클릭되었습니다.');
   };
 
-  const isEmailButtonDisabled =
+  const isSendButtonDisabled =
     !email ||
     !!errors.email ||
     isSubmitting ||
     checking ||
-    Boolean(isDuplicate);
+    Boolean(isDuplicate) ||
+    sendCodeMutation.isPending;
 
-  const isCodeButtonDisabled = !name || !!errors.name || isSubmitting;
+  const isVerifyButtonDisabled = !name || !!errors.name || isSubmitting;
 
   return (
     <AuthCard title="회원가입" linkTo="login">
@@ -138,7 +139,7 @@ export default function SignUpStep1Page() {
                   size="lg"
                   placeholder="이메일을 입력해주세요."
                   isrightbutton={true}
-                  rightButtonDisabled={isEmailButtonDisabled}
+                  rightButtonDisabled={isSendButtonDisabled}
                   onRightButtonClick={handleEmailSendClick}
                   rules={{
                     required: '이메일은 필수 입력입니다.',
@@ -168,7 +169,7 @@ export default function SignUpStep1Page() {
                 size="lg"
                 placeholder="인증 6자리를 입력해주세요."
                 isrightbutton={true}
-                rightButtonDisabled={isCodeButtonDisabled}
+                rightButtonDisabled={isVerifyButtonDisabled}
                 onRightButtonClick={handleEmailVerifyClick}
                 rules={{
                   required: '인증번호는 필수 입력입니다.',

--- a/src/components/products/signup/step1/SignupStep1Page.tsx
+++ b/src/components/products/signup/step1/SignupStep1Page.tsx
@@ -97,58 +97,48 @@ export default function SignUpStep1Page() {
             noValidate
             className="w-full"
           >
-            <div className="flex flex-col gap-[0.75rem]">
-              <div className="flex flex-row items-center gap-[0.5rem]">
-                <Input
-                  name="email"
-                  type="text"
-                  label="아이디"
-                  size="xs"
-                  placeholder="이메일을 입력해주세요."
-                  rules={{
-                    required: '이메일은 필수 입력입니다.',
-                    pattern: {
-                      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-                      message: '올바른 이메일 형식을 입력해주세요.',
-                    },
-                  }}
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="tab:w-[6.8125rem] w-[5.8125rem]"
+            <div className="flex flex-col gap-[1.5rem]">
+              <Input
+                name="email"
+                type="text"
+                label="아이디"
+                size="lg"
+                placeholder="이메일을 입력해주세요."
+                isrightbutton={true}
+                rules={{
+                  required: '이메일은 필수 입력입니다.',
+                  pattern: {
+                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                    message: '올바른 이메일 형식을 입력해주세요.',
+                  },
+                }}
+              >
+                인증하기
+              </Input>
+              {duplicateMessage && (
+                <p
+                  className={`mt-3 text-sm ${
+                    isDuplicate ? 'text-red-500' : 'text-[#bf5eff]'
+                  }`}
                 >
-                  인증하기
-                </Button>
-                {duplicateMessage && (
-                  <p
-                    className={`mt-3 text-sm ${
-                      isDuplicate ? 'text-red-500' : 'text-[#bf5eff]'
-                    }`}
-                  >
-                    {duplicateMessage}
-                  </p>
-                )}
-              </div>
-              <div className="flex flex-row items-center gap-[0.5rem]">
-                <Input
-                  name="name"
-                  type="text"
-                  label="인증번호 입력"
-                  size="xs"
-                  placeholder="인증 6자리를 입력해주세요."
-                  rules={{
-                    required: '인증번호는 필수 입력입니다.',
-                  }}
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="tab:w-[6.8125rem] w-[5.8125rem]"
-                >
-                  인증확인
-                </Button>
-              </div>
+                  {duplicateMessage}
+                </p>
+              )}
+
+              <Input
+                name="name"
+                type="text"
+                label="인증번호 입력"
+                size="lg"
+                placeholder="인증 6자리를 입력해주세요."
+                isrightbutton={true}
+                rules={{
+                  required: '인증번호는 필수 입력입니다.',
+                }}
+              >
+                인증확인
+              </Input>
+
               <Input
                 name="password"
                 type="password"

--- a/src/components/products/signup/step2/SignupStep2Page.tsx
+++ b/src/components/products/signup/step2/SignupStep2Page.tsx
@@ -103,9 +103,9 @@ export default function SignupStep2Page() {
       const profileImagePath = profileImageUrl;
       const fullData = {
         email,
-        username: name,
+        username: data.nickname,
         password,
-        nickname: data.nickname,
+        nickname: name,
         preferredGenres,
         preferredBandSessions,
         profileImagePath,

--- a/src/hooks/queries/auth/useSendCodeMutation.ts
+++ b/src/hooks/queries/auth/useSendCodeMutation.ts
@@ -1,0 +1,25 @@
+import { postSendCode } from '@/lib/auth/sendcode';
+import { useToastStore } from '@/stores/useToastStore';
+import { handleAuthApiError } from '@/utils/authApiError';
+import { useMutation } from '@tanstack/react-query';
+
+export const useSendCodeMutation = () => {
+  return useMutation({
+    mutationFn: ({ email }: { email: string }) => postSendCode({ email }),
+    onSuccess: (data) => {
+      if (data && data.success === false) {
+        useToastStore
+          .getState()
+          .show(data.message || '인증 코드 전송에 실패했습니다.');
+        return;
+      }
+      useToastStore.getState().show('인증 코드가 전송되었습니다.');
+    },
+    onError: (error) => {
+      handleAuthApiError(error, '인증 코드 전송 중 오류가 발생했습니다.', {
+        section: 'auth',
+        action: 'send_email_code',
+      });
+    },
+  });
+};

--- a/src/hooks/queries/auth/useVerifyCodeMutation.ts
+++ b/src/hooks/queries/auth/useVerifyCodeMutation.ts
@@ -1,0 +1,26 @@
+import { postVerifyCode } from '@/lib/auth/verifycode';
+import { useToastStore } from '@/stores/useToastStore';
+import { handleAuthApiError } from '@/utils/authApiError';
+import { useMutation } from '@tanstack/react-query';
+
+export const useVerifyCodeMutation = () => {
+  return useMutation({
+    mutationFn: ({ email, code }: { email: string; code: string }) =>
+      postVerifyCode({ email, code }),
+    onSuccess: (data) => {
+      if (data && data.success === false) {
+        useToastStore
+          .getState()
+          .show(data.message || '인증 코드 확인에 실패했습니다.');
+        return;
+      }
+      useToastStore.getState().show('인증 코드가 확인되었습니다.');
+    },
+    onError: (error) => {
+      handleAuthApiError(error, '인증 코드 전송 중 오류가 발생했습니다.', {
+        section: 'auth',
+        action: 'verify_email_code',
+      });
+    },
+  });
+};

--- a/src/lib/auth/sendcode.ts
+++ b/src/lib/auth/sendcode.ts
@@ -9,7 +9,7 @@ interface SendemailResponse {
   message: string;
 }
 
-export async function postsendcode({
+export async function postSendCode({
   email,
 }: SendemailRequest): Promise<SendemailResponse> {
   return await apiClient.post<SendemailResponse>('/auth/email/send-code', {

--- a/src/lib/auth/sendcode.ts
+++ b/src/lib/auth/sendcode.ts
@@ -1,0 +1,18 @@
+import { apiClient } from '@/utils/apiClient';
+
+interface SendemailRequest {
+  email: string;
+}
+
+interface SendemailResponse {
+  success: boolean;
+  message: string;
+}
+
+export async function postsendcode({
+  email,
+}: SendemailRequest): Promise<SendemailResponse> {
+  return await apiClient.post<SendemailResponse>('/auth/email/send-code', {
+    email,
+  });
+}

--- a/src/lib/auth/verifycode.ts
+++ b/src/lib/auth/verifycode.ts
@@ -1,0 +1,21 @@
+import { apiClient } from '@/utils/apiClient';
+
+interface VerifyemailRequest {
+  email: string;
+  code: string;
+}
+
+interface VerifyemailResponse {
+  success: boolean;
+  message: string;
+}
+
+export async function postverifycode({
+  email,
+  code,
+}: VerifyemailRequest): Promise<VerifyemailResponse> {
+  return await apiClient.post<VerifyemailResponse>('/auth/email/verify-code', {
+    email,
+    code,
+  });
+}

--- a/src/lib/auth/verifycode.ts
+++ b/src/lib/auth/verifycode.ts
@@ -10,7 +10,7 @@ interface VerifyemailResponse {
   message: string;
 }
 
-export async function postverifycode({
+export async function postVerifyCode({
   email,
   code,
 }: VerifyemailRequest): Promise<VerifyemailResponse> {


### PR DESCRIPTION
## 연관된 이슈

close #170

## 작업내용
- 회원가입 페이지 반응형 레이아웃
- input 리팩토링
- 이메일 인증 api 추가
- 버튼 비활성화 옵션 추가

## 체크리스트
- 추가로 필요한 기능이 있는지 알려주시면 좋을 것 같아요

## 스크린샷
- 반응형 레이아웃(데스크탑, 태블릿)
<img width="370" alt="스크린샷 2025-06-19 오후 3 30 50" src="https://github.com/user-attachments/assets/d1077929-9d3a-4e2b-98ae-826f1c5f0e3a" />

- 반응형 레이아웃(모바일)
<img width="280" alt="스크린샷 2025-06-19 오후 3 30 57" src="https://github.com/user-attachments/assets/a3b3f4da-61cf-409d-b040-20685970e6b3" />

- 영상
https://github.com/user-attachments/assets/a2973809-91be-4d3e-80d1-3492d30513d9

