### PR TITLE
[리팩토링] 쿼리키 계층화

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,6 @@ export default async function Home({ searchParams }: HomeProps) {
 
   await prefetchCommonInfiniteQuery({
     queryClient,
-    key: 'list',
     genres: defaultGenres,
     sessions: defaultSessions,
     size: 8,

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -117,7 +117,10 @@ export default function JamPage({
         onSuccess: (response) => {
           localStorage.removeItem(TEMP_STORAGE_KEY);
           queryClient.refetchQueries({
-            queryKey: ['list'],
+            predicate: (query) =>
+              query.queryKey &&
+              query.queryKey[0] === 'gatherings' &&
+              query.queryKey[1] === 'list',
           });
           router.push(`/?showShareModal=true&groupId=${response.id}`);
         },

--- a/src/components/products/mypage/MyPageContent.tsx
+++ b/src/components/products/mypage/MyPageContent.tsx
@@ -13,7 +13,6 @@ import {
 import { usePrefetchedCount } from '@/hooks/queries/gather/usePrefetchedCoint';
 import { useReviewToWriteInfiniteQuery } from '@/hooks/queries/review/usePrefetchReview';
 import { useReviewInfiniteQuery } from '@/hooks/queries/review/useReviewInfiniteQuery';
-import { useUserMeQuery } from '@/hooks/queries/user/useUserMeQuery';
 import { useQueryTab } from '@/hooks/useQueryTab';
 import clsx from 'clsx';
 import { useMemo } from 'react';
@@ -45,11 +44,9 @@ export default function MyPage() {
     selector: (data) => data.totalElements,
   });
 
-  const { data: user } = useUserMeQuery();
   const { data: write } = useReviewToWriteInfiniteQuery({
     size: 8,
     includeCanceled: false,
-    id: user?.id as number,
   });
 
   const writeCount =
@@ -57,7 +54,6 @@ export default function MyPage() {
       .length ?? 0;
   const { data: review } = useReviewInfiniteQuery({
     size: 8,
-    id: user?.id as number,
   });
 
   const reviewCount = review?.pages[0].totalElements ?? 0;

--- a/src/components/products/mypage/review/ReviewList.tsx
+++ b/src/components/products/mypage/review/ReviewList.tsx
@@ -12,7 +12,6 @@ export default function ReviewList() {
   const { data, fetchNextPage, hasNextPage, isFetching, isError } =
     useReviewInfiniteQuery({
       size: 8,
-      id: user?.id as number,
     });
   useSentryErrorLogger({
     isError: !!isError,

--- a/src/components/products/mypage/review/ReviewStatus.tsx
+++ b/src/components/products/mypage/review/ReviewStatus.tsx
@@ -1,15 +1,14 @@
 'use client';
-import { useUserMeQuery } from '@/hooks/queries/user/useUserMeQuery';
 import { getStatus } from '@/lib/review/received';
 import { useQuery } from '@tanstack/react-query';
 
 import ReviewStatusItem from './ReviewsReceived';
 import SkeletonStatus from './SkeletonStatus';
+import { userKeys } from '@/hooks/queries/queryKeys';
 
 export default function ReviewStatus() {
-  const { data: user } = useUserMeQuery();
   const { data } = useQuery({
-    queryKey: ['getStatus', user?.id],
+    queryKey: userKeys.reviews.statistics(),
     queryFn: getStatus,
   });
   if (!data) return <SkeletonStatus />;

--- a/src/components/products/mypage/towrite/ReviewsToWrite.tsx
+++ b/src/components/products/mypage/towrite/ReviewsToWrite.tsx
@@ -13,7 +13,6 @@ export default function ReviewsToWrite() {
     useReviewToWriteInfiniteQuery({
       size: 8,
       includeCanceled: false,
-      id: user?.id as number,
     });
   useSentryErrorLogger({
     isError: !!isError,

--- a/src/components/products/recruit/RecruitPage.tsx
+++ b/src/components/products/recruit/RecruitPage.tsx
@@ -24,7 +24,6 @@ export default function RecruitPage({
   const router = useRouter();
   const { data, fetchNextPage, hasNextPage, isFetching } =
     useCommonInfiniteQuery({
-      key: 'list',
       size: 8,
       genres,
       sessions,

--- a/src/hooks/queries/gather/useGatherMeCreate.ts
+++ b/src/hooks/queries/gather/useGatherMeCreate.ts
@@ -1,13 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
 import { GetUserGatheringsParams } from '@/types/gather';
 import { getUserCreatedGatherings } from '@/lib/gathering/created';
+import { userKeys } from '../queryKeys';
 
 export const gatherMeCreateQuery = ({
   page,
   size,
   includeCanceled,
 }: GetUserGatheringsParams) => ({
-  queryKey: ['me', 'created', page, size, includeCanceled],
+  queryKey: userKeys.myCreatedGatherings({
+    page,
+    size,
+    includeCanceled,
+  }) as unknown as unknown[],
   queryFn: () => getUserCreatedGatherings({ page, size, includeCanceled }),
 });
 
@@ -19,7 +24,11 @@ export const useGatherMeCreate = (
   },
 ) =>
   useQuery({
-    queryKey: ['me', 'created', page, size, includeCanceled],
+    queryKey: userKeys.myCreatedGatherings({
+      page,
+      size,
+      includeCanceled,
+    }) as unknown as unknown[],
     queryFn: () => getUserCreatedGatherings({ page, size, includeCanceled }),
     retry: true,
     staleTime: 5 * 60 * 1000,

--- a/src/hooks/queries/gather/useGatherMeParticipants.ts
+++ b/src/hooks/queries/gather/useGatherMeParticipants.ts
@@ -1,13 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
 import { getUserParticipantsGatherings } from '@/lib/gathering/participants';
 import { GetUserGatheringsParams } from '@/types/gather';
+import { userKeys } from '../queryKeys';
 
 export const gatherMeParticipantsQuery = ({
   page,
   size,
   includeCanceled,
 }: GetUserGatheringsParams) => ({
-  queryKey: ['me', 'participants', page, size, includeCanceled],
+  queryKey: userKeys.myParticipatedGatherings({
+    page,
+    size,
+    includeCanceled,
+  }) as unknown as unknown[],
   queryFn: () => getUserParticipantsGatherings({ page, size, includeCanceled }),
 });
 
@@ -19,7 +24,11 @@ export const useGatherMeParticipants = (
   },
 ) =>
   useQuery({
-    queryKey: ['me', 'participants', page, size, includeCanceled],
+    queryKey: userKeys.myParticipatedGatherings({
+      page,
+      size,
+      includeCanceled,
+    }) as unknown as unknown[],
     queryFn: () =>
       getUserParticipantsGatherings({ page, size, includeCanceled }),
     retry: true,

--- a/src/hooks/queries/gatherings/useApproveParticipantMutation.ts
+++ b/src/hooks/queries/gatherings/useApproveParticipantMutation.ts
@@ -2,6 +2,7 @@ import { approveParticipant } from '@/lib/gatherings/gatherings';
 import { useToastStore } from '@/stores/useToastStore';
 import { handleAuthApiError } from '@/utils/authApiError';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { gatheringKeys } from '../queryKeys';
 
 export const useApproveParticipantMutation = () => {
   const queryClient = useQueryClient();
@@ -17,17 +18,19 @@ export const useApproveParticipantMutation = () => {
     onSuccess: (data, { gatheringId }) => {
       useToastStore.getState().show('참가가 승인되었습니다.');
       queryClient.invalidateQueries({
-        queryKey: ['gatheringParticipants', gatheringId],
+        queryKey: gatheringKeys.details(gatheringId).participants,
       });
       queryClient.invalidateQueries({
-        queryKey: ['gatheringDetail', gatheringId],
+        queryKey: gatheringKeys.details(gatheringId).detail,
       });
       queryClient.invalidateQueries({
-        queryKey: ['list'],
+        predicate: (query) =>
+          query.queryKey &&
+          query.queryKey[0] === 'gatherings' &&
+          query.queryKey[1] === 'list',
       });
     },
     onError: (error) => {
-      // console.error('참가 승인 실패:', error);
       handleAuthApiError(error, '참가 승인 실패했습니다.', {
         section: 'gather',
         action: 'approval_gather',

--- a/src/hooks/queries/gatherings/useCancelParticipateGathering.ts
+++ b/src/hooks/queries/gatherings/useCancelParticipateGathering.ts
@@ -2,6 +2,7 @@ import { cancelParticipateGathering } from '@/lib/gatherings/gatherings';
 import { useToastStore } from '@/stores/useToastStore';
 import { handleAuthApiError } from '@/utils/authApiError';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { gatheringKeys } from '../queryKeys';
 
 export const useCancelParticipateGatheringMutation = () => {
   const queryClient = useQueryClient();
@@ -17,14 +18,13 @@ export const useCancelParticipateGatheringMutation = () => {
     onSuccess: (data) => {
       useToastStore.getState().show(data.message);
       queryClient.invalidateQueries({
-        queryKey: ['gatheringDetail', data.gatheringId],
+        queryKey: gatheringKeys.details(data.gatheringId).detail,
       });
       queryClient.invalidateQueries({
-        queryKey: ['gatheringParticipants', data.gatheringId],
+        queryKey: gatheringKeys.details(data.gatheringId).participants,
       });
     },
     onError: (error) => {
-      // console.error('참여 취소 실패:', error);
       handleAuthApiError(error, '참여 취소 중 문제가 발생했습니다.', {
         section: 'gather',
         action: 'cancel_gather',

--- a/src/hooks/queries/gatherings/useGatheringsDetailQuery.ts
+++ b/src/hooks/queries/gatherings/useGatheringsDetailQuery.ts
@@ -1,13 +1,14 @@
 import { getGatheringDetail } from '@/lib/gatherings/gatherings';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { GatheringDetailResponse } from '@/types/gathering';
+import { gatheringKeys } from '../queryKeys';
 
 export const useGatheringDetailQuery = (
   id: number,
   options?: Partial<UseQueryOptions<GatheringDetailResponse>>,
 ) => {
   return useQuery<GatheringDetailResponse>({
-    queryKey: ['gatheringDetail', id],
+    queryKey: gatheringKeys.details(id).detail,
     queryFn: () => getGatheringDetail(id),
     enabled: !!id,
     ...options,

--- a/src/hooks/queries/gatherings/useGatheringsParticipantsQuery.ts
+++ b/src/hooks/queries/gatherings/useGatheringsParticipantsQuery.ts
@@ -1,13 +1,14 @@
 import { getGatheringParticipants } from '@/lib/gatherings/gatherings';
 import { ParticipantsResponse } from '@/types/gathering';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { gatheringKeys } from '../queryKeys';
 
 export const useGatheringParticipantsQuery = (
   id: number,
   options?: Partial<UseQueryOptions<ParticipantsResponse>>,
 ) => {
   return useQuery({
-    queryKey: ['gatheringParticipants', id],
+    queryKey: gatheringKeys.details(id).participants,
     queryFn: () => getGatheringParticipants(id),
     enabled: !!id,
     ...options,

--- a/src/hooks/queries/gatherings/useParticipateGatheringsMutation.ts
+++ b/src/hooks/queries/gatherings/useParticipateGatheringsMutation.ts
@@ -2,6 +2,7 @@ import { postParticipateGatherings } from '@/lib/gatherings/gatherings';
 import { BandSessionType } from '@/types/tags';
 import { handleAuthApiError } from '@/utils/authApiError';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { gatheringKeys } from '../queryKeys';
 
 interface ParticipateGatheringParams {
   id: number;
@@ -21,14 +22,13 @@ export const useParticipateGatheringMutation = () => {
       postParticipateGatherings(id, bandSession, introduction),
     onSuccess: (data) => {
       queryClient.invalidateQueries({
-        queryKey: ['gatheringDetail', data.gatheringId],
+        queryKey: gatheringKeys.details(data.gatheringId).detail,
       });
       queryClient.invalidateQueries({
-        queryKey: ['gatheringParticipants', data.gatheringId],
+        queryKey: gatheringKeys.details(data.gatheringId).participants,
       });
     },
     onError: (error) => {
-      // console.error('모임 참여 신청 실패:', error);
       handleAuthApiError(error, '모임 참여 신청 중 문제가 발생했어요.', {
         section: 'gather',
         action: 'register_gather',

--- a/src/hooks/queries/gatherings/useRejectParticipantMutation.ts
+++ b/src/hooks/queries/gatherings/useRejectParticipantMutation.ts
@@ -2,6 +2,7 @@ import { rejectParticipant } from '@/lib/gatherings/gatherings';
 import { useToastStore } from '@/stores/useToastStore';
 import { handleAuthApiError } from '@/utils/authApiError';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { gatheringKeys } from '../queryKeys';
 
 export const useRejectParticipantMutation = () => {
   const queryClient = useQueryClient();
@@ -17,14 +18,13 @@ export const useRejectParticipantMutation = () => {
     onSuccess: (data, { gatheringId }) => {
       useToastStore.getState().show('참가 거절 처리되었습니다.');
       queryClient.invalidateQueries({
-        queryKey: ['gatheringParticipants', gatheringId],
+        queryKey: gatheringKeys.details(gatheringId).participants,
       });
       queryClient.invalidateQueries({
-        queryKey: ['gatheringDetail', gatheringId],
+        queryKey: gatheringKeys.details(gatheringId).detail,
       });
     },
     onError: (error) => {
-      // console.error('참가 거절 실패:', error);
       handleAuthApiError(error, '참가 거절 중 오류가 발생했습니다.', {
         section: 'gather',
         action: 'refuse_gather',

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -1,0 +1,76 @@
+export const gatheringKeys = {
+  all: ['gatherings'] as const,
+
+  // 전체 모임 목록
+  list: (filters: {
+    page?: number;
+    size?: number;
+    sort?: string;
+    genres?: string[];
+    sessions?: string[];
+  }) => [...gatheringKeys.all, 'list', filters] as const,
+
+  // 개별 모임
+  details: (id: number) => ({
+    // 모임 상세
+    detail: [...gatheringKeys.all, id, 'detail'] as const,
+    // 모임의 리뷰 목록
+    reviews: [...gatheringKeys.all, id, 'reviews'] as const,
+    // 모임 참가자 목록
+    participants: [...gatheringKeys.all, id, 'participants'] as const,
+    // 모임 참가자의 통합 리뷰 통계, 프로필 조회
+    participantReviewProfile: (userId: number) =>
+      [
+        ...gatheringKeys.all,
+        id,
+        'participants',
+        userId,
+        'reviewProfile',
+      ] as const,
+  }),
+};
+
+export const userKeys = {
+  base: ['user'] as const,
+
+  // 로그인한 사용자 정보
+  me: () => [...userKeys.base, 'me'] as const,
+
+  // 내가 생성한 모임 목록
+  myCreatedGatherings: () =>
+    [...userKeys.base, 'gatherings', 'created'] as const,
+
+  // 내가 신청한 모임 목록
+  myParticipatedGatherings: () =>
+    [...userKeys.base, 'gatherings', 'participated'] as const,
+
+  // 내 리뷰 관련
+  reviews: {
+    // 내가 작성한 리뷰
+    written: () => [...userKeys.base, 'reviews', 'written'] as const,
+    // 내가 작성하지 않은 참가자 목록
+    unwritten: () => [...userKeys.base, 'reviews', 'unwritten'] as const,
+    // 내가 받은 리뷰 목록
+    received: () => [...userKeys.base, 'reviews', 'received'] as const,
+    // 받은 리뷰 평가항목별 통계 정보
+    statistics: () =>
+      [...userKeys.base, 'reviews', 'received', 'statistics'] as const,
+  },
+
+  // 영상 관련
+  uploadedVideos: (userId?: string) =>
+    userId
+      ? ([...userKeys.base, 'videos', userId] as const)
+      : ([...userKeys.base, 'videos', 'me'] as const),
+};
+
+export const videoKeys = {
+  all: ['videos'] as const,
+
+  // 전체 영상 리스트
+  list: (filters: { page?: number; take?: number; order?: string }) =>
+    [...videoKeys.all, 'list', filters] as const,
+
+  // 영상 상세
+  detail: (videoId: number) => [...videoKeys.all, 'detail', videoId] as const,
+};

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -3,7 +3,6 @@ export const gatheringKeys = {
 
   // 전체 모임 목록
   list: (filters: {
-    page?: number;
     size?: number;
     sort?: string;
     genres?: string[];
@@ -37,12 +36,18 @@ export const userKeys = {
   me: () => [...userKeys.base, 'me'] as const,
 
   // 내가 생성한 모임 목록
-  myCreatedGatherings: () =>
-    [...userKeys.base, 'gatherings', 'created'] as const,
+  myCreatedGatherings: (filters: {
+    page?: number | undefined;
+    size?: number | undefined;
+    includeCanceled: boolean | undefined;
+  }) => [...userKeys.base, 'gatherings', 'created', filters] as const,
 
   // 내가 신청한 모임 목록
-  myParticipatedGatherings: () =>
-    [...userKeys.base, 'gatherings', 'participated'] as const,
+  myParticipatedGatherings: (filters: {
+    page?: number | undefined;
+    size?: number | undefined;
+    includeCanceled: boolean | undefined;
+  }) => [...userKeys.base, 'gatherings', 'participated', filters] as const,
 
   // 내 리뷰 관련
   reviews: {

--- a/src/hooks/queries/recruit/useRecruit.ts
+++ b/src/hooks/queries/recruit/useRecruit.ts
@@ -2,9 +2,9 @@ import { getRecruit } from '@/lib/recruit/recruit';
 import { RecruitResponse } from '@/types/recruit';
 import { BandSession, Genre } from '@/types/tags';
 import { QueryClient, useInfiniteQuery } from '@tanstack/react-query';
+import { gatheringKeys } from '../queryKeys';
 
 interface CommonQueryParams {
-  key: string;
   size: number;
   sort: string;
   genres: Genre[];
@@ -12,14 +12,13 @@ interface CommonQueryParams {
 }
 
 export const useCommonInfiniteQuery = ({
-  key,
   size,
   sort,
   genres,
   sessions,
 }: CommonQueryParams) => {
   return useInfiniteQuery({
-    queryKey: [key, genres, sessions],
+    queryKey: gatheringKeys.list({ size, sort, genres, sessions }),
     queryFn: ({ pageParam = 0 }) =>
       getRecruit({ pageParam, size, sort, genres, sessions }),
     initialPageParam: 0,
@@ -30,16 +29,16 @@ export const useCommonInfiniteQuery = ({
     staleTime: 1000 * 60 * 1,
   });
 };
+
 export const prefetchCommonInfiniteQuery = async ({
   queryClient,
-  key,
   size,
   sort,
   genres,
   sessions,
 }: CommonQueryParams & { queryClient: QueryClient }) => {
   return await queryClient.prefetchInfiniteQuery({
-    queryKey: [key, genres, sessions],
+    queryKey: gatheringKeys.list({ size, sort, genres, sessions }),
     queryFn: ({ pageParam = 0 }) =>
       getRecruit({ pageParam, size, sort, genres, sessions }),
     initialPageParam: 0,

--- a/src/hooks/queries/review/usePostReviewMutation.ts
+++ b/src/hooks/queries/review/usePostReviewMutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postReview } from '@/lib/review/review';
 import { PostReviewRequest } from '@/types/review';
+import { userKeys } from '../queryKeys';
 
 export const usePostReviewMutation = () => {
   const queryClient = useQueryClient();
@@ -8,7 +9,7 @@ export const usePostReviewMutation = () => {
   return useMutation({
     mutationFn: (data: PostReviewRequest) => postReview(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['writtenReviews'] });
+      queryClient.invalidateQueries({ queryKey: userKeys.reviews.written() });
     },
   });
 };

--- a/src/hooks/queries/review/usePrefetchReview.ts
+++ b/src/hooks/queries/review/usePrefetchReview.ts
@@ -3,10 +3,13 @@ import { getReviewWrites } from '@/lib/review/towrite';
 import { RecruitResponse } from '@/types/recruit';
 import { ReviewRequest } from '@/types/review';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { gatheringKeys, userKeys } from '../queryKeys';
 
 export const useReviewQuery = ({ gatheringId, userId }: ReviewRequest) => {
   return useQuery({
-    queryKey: ['prefetch_review', gatheringId, userId],
+    queryKey: gatheringKeys
+      .details(gatheringId)
+      .participantReviewProfile(userId),
     queryFn: () => getReviewRead({ gatheringId, userId }),
   });
 };
@@ -14,16 +17,14 @@ export const useReviewQuery = ({ gatheringId, userId }: ReviewRequest) => {
 interface ReivewProps {
   size: number;
   includeCanceled: boolean;
-  id: number;
 }
 
 export const useReviewToWriteInfiniteQuery = ({
   size,
   includeCanceled,
-  id,
 }: ReivewProps) => {
   return useInfiniteQuery({
-    queryKey: ['getReviewWrite', includeCanceled, id],
+    queryKey: userKeys.myParticipatedGatherings({ size, includeCanceled }),
     queryFn: ({ pageParam = 0 }) =>
       getReviewWrites({ pageParam, size, includeCanceled }),
     initialPageParam: 0,

--- a/src/hooks/queries/review/useReviewInfiniteQuery.ts
+++ b/src/hooks/queries/review/useReviewInfiniteQuery.ts
@@ -1,15 +1,15 @@
 import { getReview } from '@/lib/review/received';
 import { ReviewResponse } from '@/types/review';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { userKeys } from '../queryKeys';
 
 interface ReviewProps {
   size: number;
-  id: number;
 }
 
-export const useReviewInfiniteQuery = ({ size, id }: ReviewProps) => {
+export const useReviewInfiniteQuery = ({ size }: ReviewProps) => {
   return useInfiniteQuery({
-    queryKey: ['received-reviews', id],
+    queryKey: userKeys.reviews.received(),
     queryFn: ({ pageParam = 0 }) => getReview({ pageParam, size }),
     initialPageParam: 0,
     getNextPageParam: (lastPage: ReviewResponse) =>

--- a/src/hooks/queries/review/useWrittenReviewsQuery.ts
+++ b/src/hooks/queries/review/useWrittenReviewsQuery.ts
@@ -1,12 +1,13 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { getWrittenReviews } from '@/lib/review/written';
 import { ReviewItem } from '@/types/review';
+import { userKeys } from '../queryKeys';
 
 export const useWrittenReviewsQuery = (
   options?: Partial<UseQueryOptions<ReviewItem[]>>,
 ) => {
   return useQuery({
-    queryKey: ['writtenReviews'],
+    queryKey: userKeys.reviews.written(),
     queryFn: getWrittenReviews,
     ...options,
   });

--- a/src/hooks/queries/user/useUpdateProfile.ts
+++ b/src/hooks/queries/user/useUpdateProfile.ts
@@ -1,5 +1,6 @@
 import { putUpdateProfile } from '@/lib/mypage/updateprofile';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { userKeys } from '../queryKeys';
 
 export const useUpdateProfile = () => {
   const queryClient = useQueryClient();
@@ -9,7 +10,7 @@ export const useUpdateProfile = () => {
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['me'],
+        queryKey: userKeys.me(),
       });
     },
   });

--- a/src/hooks/queries/user/useUpdateProfileImage.ts
+++ b/src/hooks/queries/user/useUpdateProfileImage.ts
@@ -1,5 +1,6 @@
 import { putUpdateProfileImage } from '@/lib/mypage/updateprofileimage';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { userKeys } from '../queryKeys';
 
 export const useUpdateProfileImage = () => {
   const queryClient = useQueryClient();
@@ -9,7 +10,7 @@ export const useUpdateProfileImage = () => {
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['me'],
+        queryKey: userKeys.me(),
       });
     },
   });

--- a/src/hooks/queries/user/useUserMeQuery.ts
+++ b/src/hooks/queries/user/useUserMeQuery.ts
@@ -3,15 +3,14 @@ import { useUserStore } from '@/stores/useUserStore';
 import { UserResponse } from '@/types/user';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
+import { userKeys } from '../queryKeys';
 
 export const useUserMeQuery = () => {
-  const { setUser, user, isLoaded, isRefreshing } = useUserStore(
-    (state) => state,
-  );
+  const { setUser, isLoaded, isRefreshing } = useUserStore((state) => state);
   const isQueryReady = isLoaded && !isRefreshing;
 
   const query = useQuery<UserResponse>({
-    queryKey: ['me', user?.id],
+    queryKey: userKeys.me(),
     queryFn: getUserMe,
     retry: true,
     enabled: isQueryReady,

--- a/src/utils/authService.ts
+++ b/src/utils/authService.ts
@@ -6,6 +6,7 @@ import { queryClient } from '@/lib/react-query';
 import { apiClient } from './apiClient';
 import { useUserStore } from '@/stores/useUserStore';
 import { useErrorModalStore } from '@/stores/useErrorModalStore';
+import { userKeys } from '@/hooks/queries/queryKeys';
 
 export const login = async (loginRequest: LoginRequest): Promise<void> => {
   const result = await postLogin(loginRequest);
@@ -15,7 +16,7 @@ export const login = async (loginRequest: LoginRequest): Promise<void> => {
 
   useUserStore.getState().setUser(result.user);
 
-  queryClient.invalidateQueries({ queryKey: ['me'] });
+  queryClient.invalidateQueries({ queryKey: userKeys.me() });
 };
 
 export const signup = async (signupRequest: SignupRequest): Promise<void> => {
@@ -45,7 +46,7 @@ export const refreshAccessToken = async (): Promise<void> => {
     );
 
     tokenService.setAccessToken(accessToken);
-    queryClient.invalidateQueries({ queryKey: ['me'] });
+    queryClient.invalidateQueries({ queryKey: userKeys.me() });
   } catch {
     useErrorModalStore
       .getState()


### PR DESCRIPTION
## 연관된 이슈
close #176
### 작업내용
- 쿼리키 파일 추가

## 코멘트
- 바로 머지하려고 올린건 아니고, 코드 공유하고 의견 여쭐려고 올렸어요!
- 비디오 api도 이제 도입하게 되어서, nest api 작업 시작하기 전에 이번에는 쿼리키 계층화 적용해보면 어떨까 싶어서 만들어봤어요.  
- 적용하게 되면 이때까지 작성해둔 쿼리를 모두 수정해야합니다.
   - 쿼리키만 수정하면 되니까 귀찮긴해도 어려운 작업은 아닐거라고 생각해요!
   - 12개 쿼리에 적용하면 되는데 각자 3-5개 정도 될것같아요
   - 혼선이 있을 것 같으면 제가 한번에 수정해서 올려도 됩니다
   
## 체크리스트
- 각자 작업하신 쿼리들 의도에 맞게 작성된거같은지 하나씩 확인 부탁드려요

## 사용 예시
모임 관련: `gatheringKeys`

```ts
gatheringKeys.list({
  size: 10,
  sort: 'latest',
  genres: ['ROCK'],
  sessions: ['VOCAL', 'DRUM'],
});

gatheringKeys.details(1).detail;
gatheringKeys.details(1).reviews;
gatheringKeys.details(1).participants;
gatheringKeys.details(1).participantReviewProfile(42); // gatheringId = 1, userId = 42
```


로그인한 사용자 관련: `userKeys`

```ts
userKeys.me();

userKeys.myCreatedGatherings({
  page: 0,
  size: 10,
  includeCanceled: false,
});

userKeys.myParticipatedGatherings({
  page: 0,
  size: 10,
  includeCanceled: false,
});

userKeys.reviews.written();
userKeys.reviews.unwritten();
userKeys.reviews.received();
userKeys.reviews.statistics();

userKeys.uploadedVideos();
userKeys.uploadedVideos('user123');
```


영상 관련: `videoKeys`

```ts
videoKeys.list({
  page: 1,
  take: 10,
  order: 'latest',
});

videoKeys.detail(100); // videoId = 100
```
