### PR TITLE
[레이아웃] 모임 생성/수정 페이지 반응형 

### DIFF
--- a/src/assets/icons/ic_search.svg
+++ b/src/assets/icons/ic_search.svg
@@ -1,10 +1,10 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_743_13831)">
-<circle cx="10.4863" cy="11.2365" r="8.22243" transform="rotate(45 10.4863 11.2365)" stroke="#6B7280" stroke-width="2"/>
-<path d="M21.5872 22.3372L16.6729 17.4229" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
+<g clip-path="url(#clip0_1787_10077)">
+<circle cx="10.4863" cy="11.2363" r="8.22243" transform="rotate(45 10.4863 11.2363)" stroke="#9CA3AF" stroke-width="2"/>
+<path d="M21.5872 22.3372L16.6729 17.4229" stroke="#9CA3AF" stroke-width="2" stroke-linecap="round"/>
 </g>
 <defs>
-<clipPath id="clip0_743_13831">
+<clipPath id="clip0_1787_10077">
 <rect width="24" height="24" fill="white"/>
 </clipPath>
 </defs>

--- a/src/components/commons/DatePicker/DatePicker.tsx
+++ b/src/components/commons/DatePicker/DatePicker.tsx
@@ -80,7 +80,7 @@ export function DatePicker({ value, onChange }: DatePickerProps) {
         <button
           type="button"
           className={clsx(
-            'flex h-[2.75rem] w-[13.0625rem] items-center justify-center gap-[0.625rem] rounded-[0.5rem] bg-[#34343a] px-[1rem] text-[1rem] text-gray-100',
+            'pc:w-[210px] tab:w-[640px] pc:justify-center flex h-[2.75rem] w-[335px] items-center justify-between gap-[0.625rem] rounded-[0.5rem] bg-[#34343a] px-[1rem] text-[1rem] text-gray-100',
             isOpen ? 'border border-[#505057]' : 'border-none',
             !date && 'cursor-pointer text-gray-400',
           )}

--- a/src/components/commons/DatePicker/DatePicker.tsx
+++ b/src/components/commons/DatePicker/DatePicker.tsx
@@ -80,7 +80,7 @@ export function DatePicker({ value, onChange }: DatePickerProps) {
         <button
           type="button"
           className={clsx(
-            'pc:w-[210px] tab:w-[640px] pc:justify-center flex h-[2.75rem] w-[335px] items-center justify-between gap-[0.625rem] rounded-[0.5rem] bg-[#34343a] px-[1rem] text-[1rem] text-gray-100',
+            'pc:w-[13.125rem] tab:max-w-[40rem] pc:justify-center flex h-[2.75rem] w-full items-center justify-between gap-[0.625rem] rounded-[0.5rem] bg-[#34343a] px-[1rem] text-[1rem] text-gray-100',
             isOpen ? 'border border-[#505057]' : 'border-none',
             !date && 'cursor-pointer text-gray-400',
           )}

--- a/src/components/commons/Dropdown.tsx
+++ b/src/components/commons/Dropdown.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useRef, useState, useEffect } from 'react';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { useDeviceType } from '@/hooks/useDeviceType';
 import DropdownMenuList from './DropdownMenuList';
 
 interface DropdownProps {
@@ -51,12 +52,18 @@ export default function Dropdown({
   const setIsOpen = externalSetIsOpen || setInternalIsOpen;
   const dropdownRef = useRef<HTMLDivElement>(null);
   const displayValue = selectedDropdownMenu || '';
+  const device = useDeviceType();
+  const isMobile = device === 'mob';
 
   useEffect(() => {
     setSelectedDropdownMenu(value || '');
   }, [value]);
 
-  useClickOutside(dropdownRef, () => setIsOpen(false));
+  useClickOutside(dropdownRef, () => {
+    if (!isMobile) {
+      setIsOpen(false);
+    }
+  });
 
   const handleDropdownMenu = () => {
     setIsOpen(!isOpen);
@@ -76,7 +83,11 @@ export default function Dropdown({
       <div className="relative">
         <button
           onClick={handleDropdownMenu}
-          className={`flex items-center justify-between gap-[0.625rem] rounded-lg border-0 bg-[#34343A] text-gray-100 ${sizeClass} ${isProfile ? 'h-auto w-auto border-none bg-transparent p-0' : 'px-[1rem] py-[0.625rem]'}`}
+          className={`flex items-center justify-between gap-[0.625rem] rounded-lg border-0 bg-[#34343A] text-gray-100 ${sizeClass} ${
+            isProfile
+              ? 'h-auto w-auto border-none bg-transparent p-0'
+              : 'px-[1rem] py-[0.625rem]'
+          }`}
           type="button"
           aria-label="드롭다운 이미지 버튼"
         >
@@ -108,13 +119,30 @@ export default function Dropdown({
         </button>
 
         {isOpen && (
-          <div className={`absolute z-50 ${isProfile && 'w-[8.875rem]'}`}>
-            <DropdownMenuList
-              menuOptions={menuOptions}
-              onSelect={handleSelect}
-              size={size}
-            />
-          </div>
+          <>
+            {isMobile ? (
+              <div
+                className="fixed inset-0 z-50 bg-black/60"
+                onClick={() => setIsOpen(false)}
+              >
+                <div onClick={(e) => e.stopPropagation()}>
+                  <DropdownMenuList
+                    menuOptions={menuOptions}
+                    onSelect={handleSelect}
+                    size={size}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className={`absolute z-50 ${isProfile && 'w-[8.875rem]'}`}>
+                <DropdownMenuList
+                  menuOptions={menuOptions}
+                  onSelect={handleSelect}
+                  size={size}
+                />
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/components/commons/Dropdown.tsx
+++ b/src/components/commons/Dropdown.tsx
@@ -41,7 +41,7 @@ export default function Dropdown({
 }: DropdownProps) {
   const sizeClass = {
     sm: 'w-[9rem]',
-    md: 'w-[26rem]',
+    md: 'pc:w-[26rem] tab:w-[32.5rem] w-full',
     lg: 'w-auto',
   }[size || 'lg'];
 

--- a/src/components/commons/Dropdown.tsx
+++ b/src/components/commons/Dropdown.tsx
@@ -41,7 +41,7 @@ export default function Dropdown({
 }: DropdownProps) {
   const sizeClass = {
     sm: 'w-[9rem]',
-    md: 'pc:w-[26rem] tab:w-[32.5rem] w-[13.5rem]',
+    md: 'pc:w-[26rem] tab:w-[32.5rem] w-[14rem]',
     lg: 'w-auto',
   }[size || 'lg'];
 

--- a/src/components/commons/Dropdown.tsx
+++ b/src/components/commons/Dropdown.tsx
@@ -75,6 +75,7 @@ export default function Dropdown({
     onSelect(DropdownMenu);
   };
 
+  // isProfile일떄는 그냥 profile적용, 중앙배치
   return (
     <div
       className={`w-auto ${isProfile ? 'h-auto' : 'h-[2.75rem]'}`}
@@ -120,7 +121,7 @@ export default function Dropdown({
 
         {isOpen && (
           <>
-            {isMobile ? (
+            {isMobile && !isProfile ? (
               <div
                 className="fixed inset-0 z-50 bg-black/60"
                 onClick={() => setIsOpen(false)}
@@ -134,7 +135,9 @@ export default function Dropdown({
                 </div>
               </div>
             ) : (
-              <div className={`absolute z-50 ${isProfile && 'w-[8.875rem]'}`}>
+              <div
+                className={`absolute z-50 ${isProfile ? 'w-[8.875rem]' : ''}`}
+              >
                 <DropdownMenuList
                   menuOptions={menuOptions}
                   onSelect={handleSelect}

--- a/src/components/commons/Dropdown.tsx
+++ b/src/components/commons/Dropdown.tsx
@@ -41,7 +41,7 @@ export default function Dropdown({
 }: DropdownProps) {
   const sizeClass = {
     sm: 'w-[9rem]',
-    md: 'pc:w-[26rem] tab:w-[32.5rem] w-[14rem]',
+    md: 'w-[26rem]',
     lg: 'w-auto',
   }[size || 'lg'];
 

--- a/src/components/commons/Dropdown.tsx
+++ b/src/components/commons/Dropdown.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useRef, useState, useEffect } from 'react';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useDeviceType } from '@/hooks/useDeviceType';
 import DropdownMenuList from './DropdownMenuList';
+import { usePreventScroll } from '@/hooks/usePreventScroll';
 
 interface DropdownProps {
   /** 사용자가 드롭다운 항목을 선택했을 때 호출되는 콜백 함수 */
@@ -54,6 +55,9 @@ export default function Dropdown({
   const displayValue = selectedDropdownMenu || '';
   const device = useDeviceType();
   const isMobile = device === 'mob';
+
+  // 드롭다운이 열려있고 모바일일 때만 스크롤 방지
+  usePreventScroll(isOpen && isMobile);
 
   useEffect(() => {
     setSelectedDropdownMenu(value || '');
@@ -126,11 +130,15 @@ export default function Dropdown({
                 className="fixed inset-0 z-50 bg-black/60"
                 onClick={() => setIsOpen(false)}
               >
-                <div onClick={(e) => e.stopPropagation()}>
+                <div
+                  onClick={(e) => e.stopPropagation()}
+                  className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+                >
                   <DropdownMenuList
                     menuOptions={menuOptions}
                     onSelect={handleSelect}
                     size={size}
+                    isMobile={isMobile}
                   />
                 </div>
               </div>
@@ -142,6 +150,7 @@ export default function Dropdown({
                   menuOptions={menuOptions}
                   onSelect={handleSelect}
                   size={size}
+                  isMobile={false}
                 />
               </div>
             )}

--- a/src/components/commons/Dropdown.tsx
+++ b/src/components/commons/Dropdown.tsx
@@ -56,7 +56,6 @@ export default function Dropdown({
   const device = useDeviceType();
   const isMobile = device === 'mob';
 
-  // 드롭다운이 열려있고 모바일일 때만 스크롤 방지
   usePreventScroll(isOpen && isMobile);
 
   useEffect(() => {
@@ -79,7 +78,6 @@ export default function Dropdown({
     onSelect(DropdownMenu);
   };
 
-  // isProfile일떄는 그냥 profile적용, 중앙배치
   return (
     <div
       className={`w-auto ${isProfile ? 'h-auto' : 'h-[2.75rem]'}`}
@@ -144,7 +142,9 @@ export default function Dropdown({
               </div>
             ) : (
               <div
-                className={`absolute z-50 ${isProfile ? 'w-[8.875rem]' : ''}`}
+                className={`absolute z-50 ${
+                  isProfile ? 'pc:left-0 -right-10 w-[8.875rem]' : ''
+                }`}
               >
                 <DropdownMenuList
                   menuOptions={menuOptions}

--- a/src/components/commons/Dropdown.tsx
+++ b/src/components/commons/Dropdown.tsx
@@ -41,7 +41,7 @@ export default function Dropdown({
 }: DropdownProps) {
   const sizeClass = {
     sm: 'w-[9rem]',
-    md: 'w-[26rem]',
+    md: 'pc:w-[26rem] tab:w-[32.5rem] w-[13.5rem]',
     lg: 'w-auto',
   }[size || 'lg'];
 

--- a/src/components/commons/Dropdown.tsx
+++ b/src/components/commons/Dropdown.tsx
@@ -143,7 +143,7 @@ export default function Dropdown({
             ) : (
               <div
                 className={`absolute z-50 ${
-                  isProfile ? 'pc:left-0 -right-10 w-[8.875rem]' : ''
+                  isProfile ? '-right-10 -bottom-[0.625rem] w-[8.875rem]' : ''
                 }`}
               >
                 <DropdownMenuList

--- a/src/components/commons/DropdownMenuList.tsx
+++ b/src/components/commons/DropdownMenuList.tsx
@@ -5,12 +5,15 @@ interface DropdownMenuListProps {
   onSelect: (option: string) => void;
   /** Dropdownlist의 너비 */
   size?: 'sm' | 'md' | 'lg';
+  /** 모바일 여부 */
+  isMobile?: boolean;
 }
 
 export default function DropdownMenuList({
   menuOptions,
   onSelect,
   size,
+  isMobile = false,
 }: DropdownMenuListProps) {
   const sizeClass = {
     sm: 'w-[9rem]',
@@ -20,7 +23,7 @@ export default function DropdownMenuList({
 
   return (
     <div
-      className={`absolute ${sizeClass} gap-[0.625rem] rounded-lg border-1 border-[#505057] bg-[#34343A] text-gray-100`}
+      className={`${!isMobile ? 'absolute' : ''} ${sizeClass} gap-[0.625rem] rounded-lg border-1 border-[#505057] bg-[#34343A] text-gray-100`}
     >
       {menuOptions.map((option) => (
         <div

--- a/src/components/commons/DropdownMenuList.tsx
+++ b/src/components/commons/DropdownMenuList.tsx
@@ -14,7 +14,7 @@ export default function DropdownMenuList({
 }: DropdownMenuListProps) {
   const sizeClass = {
     sm: 'w-[9rem]',
-    md: 'w-[26rem]',
+    md: 'pc:w-[26rem] tab:w-[32.5rem] w-[14rem]',
     lg: 'w-auto',
   }[size || 'lg'];
 
@@ -26,7 +26,7 @@ export default function DropdownMenuList({
         <div
           key={option}
           onClick={() => onSelect(option)}
-          className="cursor-pointer rounded-lg px-[1rem] py-[0.625rem] hover:bg-[#464F4E]"
+          className="cursor-pointer rounded-lg px-[1rem] py-[0.625rem] hover:bg-[#594D6C]"
         >
           <span>{option}</span>
         </div>

--- a/src/components/commons/DropdownMenuList.tsx
+++ b/src/components/commons/DropdownMenuList.tsx
@@ -29,7 +29,7 @@ export default function DropdownMenuList({
         <div
           key={option}
           onClick={() => onSelect(option)}
-          className="cursor-pointer rounded-lg px-[1rem] py-[0.625rem] hover:bg-[#594D6C]"
+          className="cursor-pointer px-[1rem] py-[0.625rem] hover:bg-[#594D6C]"
         >
           <span>{option}</span>
         </div>

--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -85,7 +85,7 @@ function Input({
     sm: 'pc:w-[25rem] w-[19.4375rem]',
     // 448px
     md: 'w-[28rem]',
-    lg: 'w-auto',
+    lg: 'w-full pc:w-[896px]',
   }[size || 'lg'];
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {

--- a/src/components/commons/Modal/ModalWrapper.tsx
+++ b/src/components/commons/Modal/ModalWrapper.tsx
@@ -27,7 +27,7 @@ function ModalWrapper({
   const [mounted, setMounted] = useState(false);
 
   useClickOutside(modalRef, onClose);
-  usePreventScroll();
+  usePreventScroll(true);
 
   useEffect(() => {
     setMounted(true);

--- a/src/components/products/jam/DateFormSection.tsx
+++ b/src/components/products/jam/DateFormSection.tsx
@@ -22,7 +22,7 @@ interface DateFormSectionProps {
 
 export default function DateFormSection({ control }: DateFormSectionProps) {
   return (
-    <div className="flex gap-[1.25rem]">
+    <div className="pc:flex-row flex flex-col gap-[1.25rem]">
       {DATE_FIELDS.map(({ name, label, htmlFor }) => (
         <div key={name} className="flex flex-col gap-[0.5rem]">
           <label

--- a/src/components/products/jam/ImageEdit.tsx
+++ b/src/components/products/jam/ImageEdit.tsx
@@ -6,11 +6,13 @@ import { useFormContext } from 'react-hook-form';
 import { RegisterGatheringsRequest } from '@/types/gather';
 import EmptyImageIcon from '@/assets/icons/ic_emptyimage.svg';
 import { imgChange } from '@/utils/imgChange';
+import { useWatch } from 'react-hook-form';
 
 export default function ImageEdit() {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
-  const { setValue, watch } = useFormContext<RegisterGatheringsRequest>();
+  const { setValue } = useFormContext<RegisterGatheringsRequest>();
+  const thumbnail = useWatch({ name: 'thumbnail' });
 
   const handleOpenModal = useCallback(() => {
     setIsOpen(true);
@@ -26,11 +28,10 @@ export default function ImageEdit() {
   );
 
   useEffect(() => {
-    const thumb = watch('thumbnail');
-    if (thumb) {
-      setSelectedFileName(thumb);
+    if (thumbnail) {
+      setSelectedFileName(thumbnail);
     }
-  }, [watch('thumbnail')]);
+  }, [thumbnail]);
 
   const selectedImageSrc = selectedFileName
     ? imgChange(selectedFileName, 'banner')

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -36,7 +36,7 @@ export default function JamFormSection({
 
   return (
     <div className="mt-[2.5rem] flex h-auto w-auto max-w-[61rem] min-w-[23.4375rem] flex-col bg-[#202024] p-[2.5rem]">
-      <div className="pc:w-[27.9375rem] tab:w-[640px] flex min-w-[335px] flex-col gap-[1.5rem]">
+      <div className="pc:w-full tab:w-[40rem] flex min-w-[20.9375rem] flex-col gap-[1.5rem]">
         {/** 모임 제목 */}
         <Input
           name="name"

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -10,7 +10,7 @@ import DateFormSection from './DateFormSection';
 import GenreFormSection from './GenreFormSection';
 import TextArea from '@/components/commons/Textarea';
 
-const DIVIDER = 'mx-auto my-[2.5rem] w-[56rem] border-gray-800';
+const DIVIDER = 'my-[2.5rem] max-w-[56rem] min-w-[20.9375rem] border-gray-800';
 
 interface JamFormSectionProps {
   control: Control<RegisterGatheringsRequest>;
@@ -35,7 +35,7 @@ export default function JamFormSection({
   );
 
   return (
-    <div className="mt-[2.5rem] flex h-auto w-[61rem] flex-col bg-[#202024] p-[2.5rem]">
+    <div className="mt-[2.5rem] flex h-auto w-auto max-w-[61rem] min-w-[23.4375rem] flex-col bg-[#202024] p-[2.5rem]">
       <div className="flex flex-col gap-[1.5rem]">
         {/** 모임 제목 */}
         <Input

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -36,7 +36,7 @@ export default function JamFormSection({
 
   return (
     <div className="mt-[2.5rem] flex h-auto w-auto max-w-[61rem] min-w-[23.4375rem] flex-col bg-[#202024] p-[2.5rem]">
-      <div className="pc:w-full tab:w-[40rem] flex min-w-[20.9375rem] flex-col gap-[1.5rem]">
+      <div className="pc:w-full tab:w-[40rem] flex w-[20.9375rem] flex-col gap-[1.5rem]">
         {/** 모임 제목 */}
         <Input
           name="name"

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -10,7 +10,7 @@ import DateFormSection from './DateFormSection';
 import GenreFormSection from './GenreFormSection';
 import TextArea from '@/components/commons/Textarea';
 
-const DIVIDER = 'my-[2.5rem] max-w-[56rem] min-w-[20.9375rem] border-gray-800';
+const DIVIDER = 'my-[2.5rem] max-w-[56rem] w-full border-gray-800';
 
 interface JamFormSectionProps {
   control: Control<RegisterGatheringsRequest>;
@@ -35,8 +35,8 @@ export default function JamFormSection({
   );
 
   return (
-    <div className="mt-[2.5rem] flex h-auto w-auto max-w-[61rem] min-w-[23.4375rem] flex-col bg-[#202024] p-[2.5rem]">
-      <div className="pc:w-full tab:w-[40rem] flex w-[20.9375rem] flex-col gap-[1.5rem]">
+    <div className="pc:max-w-[60rem] mt-[2.5rem] flex h-auto w-full flex-col bg-[#202024] p-[2.5rem]">
+      <div className="pc:w-full tab:max-w-[40rem] flex w-full flex-col gap-[1.5rem]">
         {/** 모임 제목 */}
         <Input
           name="name"

--- a/src/components/products/jam/JamFormSection.tsx
+++ b/src/components/products/jam/JamFormSection.tsx
@@ -36,7 +36,7 @@ export default function JamFormSection({
 
   return (
     <div className="mt-[2.5rem] flex h-auto w-auto max-w-[61rem] min-w-[23.4375rem] flex-col bg-[#202024] p-[2.5rem]">
-      <div className="flex flex-col gap-[1.5rem]">
+      <div className="pc:w-[27.9375rem] tab:w-[640px] flex min-w-[335px] flex-col gap-[1.5rem]">
         {/** 모임 제목 */}
         <Input
           name="name"

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -131,7 +131,7 @@ export default function JamPage({
         <GroupPageLayout
           banner={<ImageEdit />}
           actionButtons={
-            <div className="pc:flex-col mt-[2.5rem] flex gap-[1rem]">
+            <div className="pc:flex-col mt-[2.5rem] flex w-full gap-[1rem]">
               {formType === 'register' && (
                 <Button
                   variant="outline"

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -131,11 +131,11 @@ export default function JamPage({
         <GroupPageLayout
           banner={<ImageEdit />}
           actionButtons={
-            <div className="pc:flex-col mt-[2.5rem] flex w-full gap-[1rem]">
+            <div className="pc:mt-[2.5rem] flex w-full flex-col gap-[1rem]">
               {formType === 'register' && (
                 <Button
                   variant="outline"
-                  className="w-[11.375rem]"
+                  className="pc:w-[11.375rem] tab:w-[680px] w-[343px]"
                   type="button"
                   onClick={handleTempSave}
                 >
@@ -144,7 +144,7 @@ export default function JamPage({
               )}
               <Button
                 variant="solid"
-                className="w-[11.375rem]"
+                className="pc:w-[11.375rem] tab:w-[680px] w-[343px]"
                 type="submit"
                 disabled={!isValid || !thumbnail}
               >

--- a/src/components/products/jam/JamPage.tsx
+++ b/src/components/products/jam/JamPage.tsx
@@ -131,11 +131,11 @@ export default function JamPage({
         <GroupPageLayout
           banner={<ImageEdit />}
           actionButtons={
-            <div className="pc:mt-[2.5rem] flex w-full flex-col gap-[1rem]">
+            <div className="pc:mt-[2.5rem] pc:items-start flex w-full flex-col items-center gap-[1rem]">
               {formType === 'register' && (
                 <Button
                   variant="outline"
-                  className="pc:w-[11.375rem] tab:w-[680px] w-[343px]"
+                  className="pc:w-[22.75rem] w-full"
                   type="button"
                   onClick={handleTempSave}
                 >
@@ -144,7 +144,7 @@ export default function JamPage({
               )}
               <Button
                 variant="solid"
-                className="pc:w-[11.375rem] tab:w-[680px] w-[343px]"
+                className="pc:w-[22.75rem] w-full"
                 type="submit"
                 disabled={!isValid || !thumbnail}
               >

--- a/src/components/products/jam/ModalImgEdit.tsx
+++ b/src/components/products/jam/ModalImgEdit.tsx
@@ -27,7 +27,7 @@ function ModalImgEdit({ onSubmit, onClose }: ModalImgEditProps) {
   const device = useDeviceType();
 
   useClickOutside(modalRef, onClose);
-  usePreventScroll();
+  usePreventScroll(true);
 
   useEffect(() => {
     const firstCount =

--- a/src/components/products/jam/ModalImgEdit.tsx
+++ b/src/components/products/jam/ModalImgEdit.tsx
@@ -7,8 +7,10 @@ import { useClickOutside } from '@/hooks/useClickOutside';
 import Button from '@/components/commons/Button';
 import { imgChange } from '@/utils/imgChange';
 import { usePreventScroll } from '@/hooks/usePreventScroll';
+import { useDeviceType } from '@/hooks/useDeviceType';
 
-const FIRST_RENDERING = 12;
+const MOBILE_FIRST_RENDERING = 6;
+const DEFAULT_FIRST_RENDERING = 12;
 const TOTAL_IMAGES = 18;
 
 interface ModalImgEditProps {
@@ -20,16 +22,20 @@ interface ModalImgEditProps {
 function ModalImgEdit({ onSubmit, onClose }: ModalImgEditProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const [visibleCount, setVisibleCount] = useState(FIRST_RENDERING);
+  const [visibleCount, setVisibleCount] = useState(DEFAULT_FIRST_RENDERING);
   const [mounted, setMounted] = useState(false);
+  const device = useDeviceType();
 
   useClickOutside(modalRef, onClose);
   usePreventScroll();
 
   useEffect(() => {
+    const firstCount =
+      device === 'mob' ? MOBILE_FIRST_RENDERING : DEFAULT_FIRST_RENDERING;
+    setVisibleCount(firstCount);
     setMounted(true);
     return () => setMounted(false);
-  }, []);
+  }, [device]);
 
   // 배너 이미지 파일명 생성 함수
   const getBannerFileName = (index: number): string => {
@@ -49,7 +55,7 @@ function ModalImgEdit({ onSubmit, onClose }: ModalImgEditProps) {
       />
       <div
         ref={modalRef}
-        className="fixed top-1/2 left-1/2 z-50 h-auto w-[57.75rem] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-3xl border-0 bg-[#242429] px-[3.25rem] py-[2.75rem]"
+        className="pc:w-[57.75rem] pc:h-[25.625rem] tab:w-[39rem] max-h-auto fixed top-1/2 left-1/2 z-50 min-h-[32.9375rem] w-[19.625rem] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-3xl border-0 bg-[#242429] px-[3.25rem] py-[2.75rem]"
       >
         <div className="flex flex-col items-center gap-[2rem]">
           <div className="flex flex-col items-center">
@@ -59,7 +65,7 @@ function ModalImgEdit({ onSubmit, onClose }: ModalImgEditProps) {
             </h2>
           </div>
 
-          <div className="grid grid-cols-6 gap-[1.25rem]">
+          <div className="pc:grid-cols-6 tab:grid-cols-4 pc:gap-[1.25rem] grid grid-cols-2 gap-[0.75rem]">
             {[...Array(visibleCount)].map((_, idx) => {
               const fileName = getBannerFileName(idx);
               const imageData = imgChange(fileName, 'banner');
@@ -95,7 +101,7 @@ function ModalImgEdit({ onSubmit, onClose }: ModalImgEditProps) {
             </button>
           )}
         </div>
-        <div className="absolute top-[3.25rem] right-[2.75rem]">
+        <div className="pc:absolute pc:top-[3.25rem] pc:right-[2.75rem] pc:mt-[0rem] mt-[1.3125rem] flex justify-center">
           <Button
             variant="solid"
             size="small"

--- a/src/components/products/jam/SearchInput.tsx
+++ b/src/components/products/jam/SearchInput.tsx
@@ -39,7 +39,7 @@ export default function SearchInput({ value, onChange }: SearchInputProps) {
         <label className="block text-sm font-semibold text-gray-100">
           모임 장소
         </label>
-        <div className="pc:w-[27.9375rem] tab:w-[640px] relative min-w-[335px] text-gray-400">
+        <div className="pc:w-[27.9375rem] tab:w-[40rem] relative w-[20.9375rem] text-gray-400">
           <label className="block cursor-pointer">
             <input
               ref={inputRef}

--- a/src/components/products/jam/SearchInput.tsx
+++ b/src/components/products/jam/SearchInput.tsx
@@ -39,7 +39,7 @@ export default function SearchInput({ value, onChange }: SearchInputProps) {
         <label className="block text-sm font-semibold text-gray-100">
           모임 장소
         </label>
-        <div className="pc:w-[27.9375rem] tab:w-[40rem] relative w-[20.9375rem] text-gray-400">
+        <div className="pc:w-full tab:max-w-[40rem] relative w-full text-gray-400">
           <label className="block cursor-pointer">
             <input
               ref={inputRef}

--- a/src/components/products/jam/SearchInput.tsx
+++ b/src/components/products/jam/SearchInput.tsx
@@ -39,7 +39,7 @@ export default function SearchInput({ value, onChange }: SearchInputProps) {
         <label className="block text-sm font-semibold text-gray-100">
           모임 장소
         </label>
-        <div className="relative w-[27.9375rem] text-gray-400">
+        <div className="pc:w-[27.9375rem] tab:w-[640px] relative min-w-[335px] text-gray-400">
           <label className="block cursor-pointer">
             <input
               ref={inputRef}

--- a/src/components/products/jam/SessionFormSection.tsx
+++ b/src/components/products/jam/SessionFormSection.tsx
@@ -98,7 +98,7 @@ export default function SessionFormSection({
   return (
     <div className="flex flex-col gap-[0.5rem]">
       <p className="text-sm font-semibold text-gray-100">모집 세션</p>
-      <div className="flex flex-row justify-between">
+      <div className="pc:gap-[0rem] pc:flex-row flex flex-col justify-between gap-[1rem]">
         <div className="flex flex-col gap-[0.75rem]">
           {sessionList.map(({ sortOption, count }, index) => (
             <SessionSelector
@@ -116,18 +116,16 @@ export default function SessionFormSection({
         <div className="flex gap-[0.75rem]">
           <Button
             variant="outline"
-            size="small"
             onClick={handleAddSession}
-            className="text-gray-100 hover:text-white"
+            className="pc:w-[109px] w-[91px] text-gray-100 hover:text-white"
           >
             추가
           </Button>
           <Button
             variant="outline"
-            size="small"
             onClick={() => handleDeleteSession(sessionList.length - 1)}
             disabled={sessionList.length === 1}
-            className="text-gray-100 hover:text-white"
+            className="pc:w-[109px] w-[91px] text-gray-100 hover:text-white"
           >
             삭제
           </Button>

--- a/src/components/products/jam/SessionSelector.tsx
+++ b/src/components/products/jam/SessionSelector.tsx
@@ -5,7 +5,7 @@ import { SESSION_TAGS, SESSION_KEY_MAP } from '@/constants/tags';
 import ArrowDown from '@/assets/icons/ic_arrowdown.svg';
 
 interface SessionSelectorProps {
-  /** 세션별 인원 수 나타냄(TODO: 변경 필요할 수도 있음) */
+  /** 세션별 인원 수 나타냄 */
   session: Record<string, number>;
   /** 현재 선택된 세션 옵션 */
   sortOption: string;

--- a/src/components/products/jam/SessionSelector.tsx
+++ b/src/components/products/jam/SessionSelector.tsx
@@ -31,21 +31,25 @@ export default function SessionSelector({
   );
 
   return (
-    <div className="flex gap-[0.75rem]">
-      <Dropdown
-        onSelect={setSortOption}
-        menuOptions={availableOptions}
-        surfixIcon={<ArrowDown />}
-        size="md"
-        value={sortOption}
-        isOpen={isDropdownOpen}
-        setIsOpen={setIsDropdownOpen}
-        placeholder="세션을 선택하세요."
-      />
-      <NumberInput
-        count={session[SESSION_KEY_MAP[sortOption]] || 1}
-        onChange={onChange}
-      />
+    <div className="flex w-full gap-[0.75rem]">
+      <div className="min-w-0">
+        <Dropdown
+          onSelect={setSortOption}
+          menuOptions={availableOptions}
+          surfixIcon={<ArrowDown />}
+          size="md"
+          value={sortOption}
+          isOpen={isDropdownOpen}
+          setIsOpen={setIsDropdownOpen}
+          placeholder="세션을 선택하세요."
+        />
+      </div>
+      <div className="flex-shrink-0">
+        <NumberInput
+          count={session[SESSION_KEY_MAP[sortOption]] || 1}
+          onChange={onChange}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/products/signup/step2/SignupStep2Page.tsx
+++ b/src/components/products/signup/step2/SignupStep2Page.tsx
@@ -103,7 +103,7 @@ export default function SignupStep2Page() {
       const profileImagePath = profileImageUrl;
       const fullData = {
         email,
-        username: name,
+        username: data.nickname,
         password,
         nickname: data.nickname,
         preferredGenres,

--- a/src/hooks/usePreventScroll.ts
+++ b/src/hooks/usePreventScroll.ts
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
 
-export const usePreventScroll = () => {
+export const usePreventScroll = (isActive: boolean) => {
   useEffect(() => {
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, []);
+    if (isActive) {
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = '';
+      };
+    }
+  }, [isActive]);
 };


### PR DESCRIPTION
## 연관된 이슈

close #172 

## 작업내용
- 반응형 작업
- 드롭다운 반응형 수정
- 드롭다운 프로필 위치값 수정
- search 이미지 수정

## 체크리스트
- 스크롤막는 훅 boolean값 추가했어요. 이렇게 안하면 드롭다운 막는게 안되더라고요.. 다른 사용한 부분 있나 찾아봤는데 없어서 제가 사용한 부분은 수정했어요.

## 스크린샷
- 프로필 드롭다운 위치값
<img width="114" alt="스크린샷 2025-06-21 오전 12 26 52" src="https://github.com/user-attachments/assets/a094b94b-7d7a-4d9f-a874-28fe0e184987" />

- 반응형페이지 + 드롭다운(데스크탑)
<img width="1103" alt="스크린샷 2025-06-21 오전 12 27 09" src="https://github.com/user-attachments/assets/4fee65ee-bfbc-4a53-8110-5de88e60a880" />
<img width="445" alt="스크린샷 2025-06-21 오전 12 28 32" src="https://github.com/user-attachments/assets/c1690c74-d6c2-46ab-946e-dc1d7fa30764" />

- 반응형페이지 + 드롭다운(태블릿)
<img width="556" alt="스크린샷 2025-06-21 오전 12 27 48" src="https://github.com/user-attachments/assets/0ef09692-f1a5-4f3b-945c-c0e899973f69" />
<img width="546" alt="스크린샷 2025-06-21 오전 12 28 27" src="https://github.com/user-attachments/assets/ec3438fc-73d7-47dc-8dd0-7c27b6f64bb1" />

- 반응형페이지 + 드롭다운(모바일)
<img width="487" alt="스크린샷 2025-06-21 오전 12 27 54" src="https://github.com/user-attachments/assets/dfcf751a-0213-4739-ac7e-34c203f66c45" />
<img width="502" alt="스크린샷 2025-06-21 오전 12 28 17" src="https://github.com/user-attachments/assets/b41a1e4f-08d7-4c67-8625-2d39406ef87e" />

