### PR TITLE
[페이지] 마이페이지 내가 올린 영상 목록

### DIFF
--- a/src/components/products/group/MemberList.tsx
+++ b/src/components/products/group/MemberList.tsx
@@ -97,7 +97,7 @@ export default function MemberList({
           {members.map((member) => (
             <MemberRow
               key={`${member.userId}-${member.bandSession}`}
-              id={member.participantId}
+              id={member.userId}
               nickname={member.userNickname}
               session={member.bandSession}
               introduction={member.introduction}

--- a/src/components/products/group/MemberList.tsx
+++ b/src/components/products/group/MemberList.tsx
@@ -97,7 +97,8 @@ export default function MemberList({
           {members.map((member) => (
             <MemberRow
               key={`${member.userId}-${member.bandSession}`}
-              id={member.userId}
+              id={member.participantId}
+              memberId={member.userId}
               nickname={member.userNickname}
               session={member.bandSession}
               introduction={member.introduction}

--- a/src/components/products/group/MemberRow.tsx
+++ b/src/components/products/group/MemberRow.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 
 interface MemberRowProps {
   id: number;
+  memberId?: number;
   selected: boolean;
   onSelectChange: (id: number) => void;
   nickname: string;
@@ -18,6 +19,7 @@ interface MemberRowProps {
 
 export default function MemberRow({
   id,
+  memberId,
   selected,
   onSelectChange,
   nickname,
@@ -43,7 +45,7 @@ export default function MemberRow({
             <ProfileImage src={profileImage} size={3} />
 
             <div className="pc:w-[8.6875rem] underline underline-offset-2">
-              <Link href={`/group/${gatheringId}/reviews/${id}`}>
+              <Link href={`/group/${gatheringId}/reviews/${memberId}`}>
                 {nickname}
               </Link>
             </div>

--- a/src/components/products/mypage/MyPageContent.tsx
+++ b/src/components/products/mypage/MyPageContent.tsx
@@ -19,12 +19,14 @@ import { useMemo } from 'react';
 import GatheringList from './gather/GatheringList';
 import GatheringListComponents from './gather/GatheringListComponents';
 import MyReview from './review/MyReview';
+import MyVideo from './video/MyVideo';
 
 type TabKey =
   | 'participating'
   | 'created'
   | 'reviews_received'
-  | 'reviews_towrite';
+  | 'reviews_towrite'
+  | 'video';
 
 export default function MyPage() {
   const { activeTab, setTab } = useQueryTab<TabKey>('tab', 'participating', [
@@ -32,6 +34,7 @@ export default function MyPage() {
     'created',
     'reviews_received',
     'reviews_towrite',
+    'video',
   ]);
 
   const participatingCount = usePrefetchedCount({
@@ -105,6 +108,12 @@ export default function MyPage() {
         label: '작성 가능한 리뷰',
         count: writeCount,
         component: <ReviewsToWrite />,
+      },
+      {
+        key: 'video',
+        label: '재밋 후기',
+        count: writeCount, // 수정 예정
+        component: <MyVideo />,
       },
     ],
     [participatingCount, createdCount, reviewCount, writeCount],

--- a/src/components/products/mypage/MyPageContent.tsx
+++ b/src/components/products/mypage/MyPageContent.tsx
@@ -20,6 +20,7 @@ import GatheringList from './gather/GatheringList';
 import GatheringListComponents from './gather/GatheringListComponents';
 import MyReview from './review/MyReview';
 import MyVideo from './video/MyVideo';
+import { userVideoCountQuery } from '@/hooks/queries/video/useUserVideoCountQuery';
 
 type TabKey =
   | 'participating'
@@ -57,6 +58,11 @@ export default function MyPage() {
       .length ?? 0;
   const { data: review } = useReviewInfiniteQuery({
     size: 8,
+  });
+
+  const videoCount = usePrefetchedCount({
+    ...userVideoCountQuery(),
+    selector: (data) => data.count,
   });
 
   const reviewCount = review?.pages[0].totalElements ?? 0;
@@ -112,11 +118,11 @@ export default function MyPage() {
       {
         key: 'video',
         label: '재밋 후기',
-        count: writeCount, // 수정 예정
+        count: videoCount,
         component: <MyVideo />,
       },
     ],
-    [participatingCount, createdCount, reviewCount, writeCount],
+    [participatingCount, createdCount, reviewCount, writeCount, videoCount],
   );
 
   const tabClass = (isActive: boolean) =>

--- a/src/components/products/mypage/video/MyVideo.tsx
+++ b/src/components/products/mypage/video/MyVideo.tsx
@@ -1,0 +1,39 @@
+import InfinityScroll from '@/components/commons/InfinityScroll';
+import { useUserVideoInfiniteQuery } from '@/hooks/queries/video/useUserVideoInfiniteQuery';
+import { VideoCard } from '../../videos/VideoCard';
+import CardSkeleton from '@/components/commons/Card/SkeletonItem';
+
+export default function MyVideo() {
+  const { data, fetchNextPage, hasNextPage, isFetching, isLoading } =
+    useUserVideoInfiniteQuery({ sort: 'latest', size: 12 });
+
+  const flatVideos = data?.pages.flatMap((page) => page.data) ?? [];
+  const isInitialLoading = isLoading && flatVideos.length === 0;
+
+  if (!data) {
+    return (
+      <div className="pc:grid-cols-4 pc:gap-x-5 pc:px-0 tab:px-6 grid grid-cols-1 gap-y-10 px-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <CardSkeleton key={i} /> // 수정 예정
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen">
+      <InfinityScroll
+        isInitialLoading={isInitialLoading}
+        list={flatVideos}
+        item={(video) => <VideoCard key={video.id} video={video} />}
+        emptyText="업로드된 영상이 없습니다."
+        hasMore={!!hasNextPage && !isFetching}
+        onInView={() => {
+          if (hasNextPage && !isFetching) {
+            fetchNextPage();
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/products/mypage/video/MyVideo.tsx
+++ b/src/components/products/mypage/video/MyVideo.tsx
@@ -1,7 +1,7 @@
 import InfinityScroll from '@/components/commons/InfinityScroll';
 import { useUserVideoInfiniteQuery } from '@/hooks/queries/video/useUserVideoInfiniteQuery';
 import { VideoCard } from '../../videos/VideoCard';
-import CardSkeleton from '@/components/commons/Card/SkeletonItem';
+import VideoCardSkeleton from '../../videos/VideoCardSkeleton';
 
 export default function MyVideo() {
   const { data, fetchNextPage, hasNextPage, isFetching, isLoading } =
@@ -13,8 +13,8 @@ export default function MyVideo() {
   if (!data) {
     return (
       <div className="pc:grid-cols-4 pc:gap-x-5 pc:px-0 tab:px-6 grid grid-cols-1 gap-y-10 px-4">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <CardSkeleton key={i} /> // 수정 예정
+        {Array.from({ length: 12 }).map((_, i) => (
+          <VideoCardSkeleton key={i} />
         ))}
       </div>
     );

--- a/src/components/products/videos/VideoCard.tsx
+++ b/src/components/products/videos/VideoCard.tsx
@@ -9,7 +9,8 @@ interface VideoCardProps {
 
 export function VideoCard({ video }: VideoCardProps) {
   const router = useRouter();
-  const formatDuration = (duration: string) => {
+  const formatDuration = (duration: string | null) => {
+    if (!duration) return '00:00';
     const [h, m, s] = duration.split(':');
     return h === '00' ? `${m}:${s}` : `${h}:${m}:${s}`;
   };

--- a/src/components/products/videos/VideoCardSkeleton.tsx
+++ b/src/components/products/videos/VideoCardSkeleton.tsx
@@ -1,0 +1,12 @@
+import ShimmerSkeleton from '@/components/commons/ShimmerSkeleton';
+
+export default function VideoCardSkeleton() {
+  return (
+    <div>
+      <ShimmerSkeleton className="pc:aspect-[16/9] tab:aspect-[87/25] aspect-[343/200] rounded-lg" />
+      <ShimmerSkeleton className="mt-2 h-4 w-30" />
+      <ShimmerSkeleton className="mt-2 h-4 w-20" />
+      <ShimmerSkeleton className="mt-2 h-4 w-30" />
+    </div>
+  );
+}

--- a/src/components/products/videos/VideoList.tsx
+++ b/src/components/products/videos/VideoList.tsx
@@ -27,6 +27,7 @@ export default function VideoList() {
         emptyText="업로드된 영상이 없습니다."
         hasMore={!!hasNextPage && !isFetching}
         onInView={() => {
+          console.log('✅ inView triggered!');
           if (hasNextPage && !isFetching) {
             fetchNextPage();
           }

--- a/src/components/products/videos/VideoList.tsx
+++ b/src/components/products/videos/VideoList.tsx
@@ -27,7 +27,6 @@ export default function VideoList() {
         emptyText="업로드된 영상이 없습니다."
         hasMore={!!hasNextPage && !isFetching}
         onInView={() => {
-          console.log('✅ inView triggered!');
           if (hasNextPage && !isFetching) {
             fetchNextPage();
           }

--- a/src/components/products/videos/VideoListControBar.tsx
+++ b/src/components/products/videos/VideoListControBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 import IcSort from '@/assets/icons/ic_sort.svg';
 import Button from '@/components/commons/Button';
+import { useRouter } from 'next/navigation';
 
 interface VideoListControlBarProps {
   sort: 'latest' | 'popular';
@@ -11,6 +12,7 @@ export default function VideoListControlBar({
   sort,
   setSort,
 }: VideoListControlBarProps) {
+  const router = useRouter();
   const sortLabel = sort === 'latest' ? '최신순' : '인기순';
 
   const toggleSort = () => {
@@ -27,7 +29,12 @@ export default function VideoListControlBar({
         <IcSort />
         {sortLabel}
       </button>
-      <Button variant="solid" className="w-[148px]">
+      <Button
+        variant="solid"
+        className="w-[148px]"
+        onClick={() => router.push('/video/upload')}
+        aria-label="재밋후기 글 작성 페이지로 이동"
+      >
         글 작성
       </Button>
     </div>

--- a/src/hooks/queries/gather/usePrefetchedCoint.ts
+++ b/src/hooks/queries/gather/usePrefetchedCoint.ts
@@ -6,7 +6,7 @@ export function usePrefetchedCount<T>({
   queryFn,
   selector,
 }: {
-  queryKey: unknown[];
+  queryKey: readonly unknown[];
   queryFn: () => Promise<T>;
   selector: (data: T) => number;
 }) {

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -63,10 +63,16 @@ export const userKeys = {
   },
 
   // 영상 관련
-  uploadedVideos: (userId?: string) =>
-    userId
+  videos: (userId?: number) => ({
+    // 유저가 업로드한 영상 목록
+    list: userId
       ? ([...userKeys.base, 'videos', userId] as const)
       : ([...userKeys.base, 'videos', 'me'] as const),
+    // 유저가 업로드한 영상 개수
+    count: userId
+      ? ([...userKeys.base, 'videosCount', userId] as const)
+      : ([...userKeys.base, 'videosCount', 'me'] as const),
+  }),
 };
 
 export const videoKeys = {

--- a/src/hooks/queries/video/useUserVideoCountQuery.ts
+++ b/src/hooks/queries/video/useUserVideoCountQuery.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { GetUserVideoCountResponse } from '@/types/video';
+import { GetUserVideoCount, GetUserVideoCountParams } from '@/lib/video/video';
+import { userKeys } from '../queryKeys';
+
+export const useUserVideoCountQuery = (params: GetUserVideoCountParams) => {
+  return useQuery<GetUserVideoCountResponse>({
+    queryKey: userKeys.videos(params.userId).count,
+    queryFn: () => GetUserVideoCount(params),
+    enabled: params.userId !== undefined,
+  });
+};
+
+export const userVideoCountQuery = (params?: GetUserVideoCountParams) => {
+  const userId = params?.userId;
+  return {
+    queryKey: userKeys.videos(userId).count,
+    queryFn: () => GetUserVideoCount({ userId }),
+  };
+};

--- a/src/hooks/queries/video/useUserVideoInfiniteQuery.ts
+++ b/src/hooks/queries/video/useUserVideoInfiniteQuery.ts
@@ -5,7 +5,7 @@ import { userKeys } from '../queryKeys';
 import { GetUserVideoListResponse } from '@/types/video';
 
 interface UseUserVideoInfiniteQueryParams {
-  userId?: string;
+  userId?: number;
   sort: 'latest' | 'popular';
   size?: number;
 }
@@ -16,7 +16,7 @@ export const useUserVideoInfiniteQuery = ({
   size = 10,
 }: UseUserVideoInfiniteQueryParams) => {
   return useInfiniteQuery({
-    queryKey: userKeys.uploadedVideos(userId),
+    queryKey: userKeys.videos(userId).list,
     queryFn: ({ pageParam = 1 }) =>
       getUserVideoList({ userId, page: pageParam, take: size, order: sort }),
     initialPageParam: 1,

--- a/src/hooks/queries/video/useUserVideoInfiniteQuery.ts
+++ b/src/hooks/queries/video/useUserVideoInfiniteQuery.ts
@@ -1,0 +1,29 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getUserVideoList } from '@/lib/video/video';
+
+import { userKeys } from '../queryKeys';
+import { GetUserVideoListResponse } from '@/types/video';
+
+interface UseUserVideoInfiniteQueryParams {
+  userId?: string;
+  sort: 'latest' | 'popular';
+  size?: number;
+}
+
+export const useUserVideoInfiniteQuery = ({
+  userId,
+  sort,
+  size = 10,
+}: UseUserVideoInfiniteQueryParams) => {
+  return useInfiniteQuery({
+    queryKey: userKeys.uploadedVideos(userId),
+    queryFn: ({ pageParam = 1 }) =>
+      getUserVideoList({ userId, page: pageParam, take: size, order: sort }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage: GetUserVideoListResponse) => {
+      const { page, totalPage } = lastPage;
+      return page < totalPage ? page + 1 : undefined;
+    },
+    staleTime: 1000 * 60 * 1,
+  });
+};

--- a/src/lib/video/video.ts
+++ b/src/lib/video/video.ts
@@ -1,4 +1,8 @@
-import { GetUserVideoListResponse, GetVideoListResponse } from '@/types/video';
+import {
+  GetUserVideoCountResponse,
+  GetUserVideoListResponse,
+  GetVideoListResponse,
+} from '@/types/video';
 import { nestApiClient } from '@/utils/apiClient';
 
 export interface GetVideoListParams {
@@ -24,7 +28,7 @@ export const getVideoList = async ({
 };
 
 export interface GetUserVideoListParams {
-  userId?: string;
+  userId?: number;
   order?: 'latest' | 'popular';
   take?: number;
   page?: number;
@@ -37,7 +41,7 @@ export const getUserVideoList = async ({
   page = 1,
 }: GetUserVideoListParams): Promise<GetUserVideoListResponse> => {
   const query = new URLSearchParams({
-    ...(userId && { userId }),
+    ...(userId !== undefined && { userId: userId.toString() }),
     order,
     take: take.toString(),
     page: page.toString(),
@@ -45,6 +49,26 @@ export const getUserVideoList = async ({
 
   const result = await nestApiClient.get<GetUserVideoListResponse>(
     `/video/user?${query}`,
+  );
+
+  return result;
+};
+
+export interface GetUserVideoCountParams {
+  userId?: number;
+}
+
+export const GetUserVideoCount = async ({
+  userId,
+}: GetUserVideoCountParams): Promise<GetUserVideoCountResponse> => {
+  const queryParams = new URLSearchParams();
+
+  if (userId !== undefined) {
+    queryParams.append('userId', userId.toString());
+  }
+
+  const result = await nestApiClient.get<GetUserVideoCountResponse>(
+    `/video/user/count?${queryParams.toString()}`,
   );
 
   return result;

--- a/src/lib/video/video.ts
+++ b/src/lib/video/video.ts
@@ -1,4 +1,4 @@
-import { GetVideoListResponse } from '@/types/video';
+import { GetUserVideoListResponse, GetVideoListResponse } from '@/types/video';
 import { nestApiClient } from '@/utils/apiClient';
 
 export interface GetVideoListParams {
@@ -20,5 +20,32 @@ export const getVideoList = async ({
   const result = await nestApiClient.get<GetVideoListResponse>(
     `/video?${query}`,
   );
+  return result;
+};
+
+export interface GetUserVideoListParams {
+  userId?: string;
+  order?: 'latest' | 'popular';
+  take?: number;
+  page?: number;
+}
+
+export const getUserVideoList = async ({
+  userId,
+  order = 'latest',
+  take = 10,
+  page = 1,
+}: GetUserVideoListParams): Promise<GetUserVideoListResponse> => {
+  const query = new URLSearchParams({
+    ...(userId && { userId }),
+    order,
+    take: take.toString(),
+    page: page.toString(),
+  }).toString();
+
+  const result = await nestApiClient.get<GetUserVideoListResponse>(
+    `/video/user?${query}`,
+  );
+
   return result;
 };

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -68,3 +68,10 @@ export interface CommentResponse {
 export interface CommentRequest {
   content: string;
 }
+
+export interface GetUserVideoListResponse {
+  page: number;
+  totalPage: number;
+  data: VideoItem[];
+  message: string;
+}

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -75,3 +75,8 @@ export interface GetUserVideoListResponse {
   data: VideoItem[];
   message: string;
 }
+
+export interface GetUserVideoCountResponse {
+  count: number;
+  message: string;
+}


### PR DESCRIPTION
## 연관된 이슈

close #184 

## 작업내용
- 내가 올린 영상 목록 마이페이지에 추가
- 영상 개수 프리패치
- 스켈레톤
- 모임 상세 참가자 리뷰 링크에 참가자아이디(userId)가 아니라 참가아이디(participantsId)가 들어가 있어서 유저를 찾을 수 없는 오류가 나서 수정해놨습니다!
- [ ] 반응형 아직 안함

## 코멘트
근데 특정 사용자가 올린 영상 리스트는 어떻게 접근하도록 해야할까요?
### 1. 영상 상세에서 닉네임 클릭시 확인가능 
-> 그러면 대충 아래처럼 탭바 없는 마이페이지 형식에 영상 리스트만 보이게 해야하는데, nest에서 프로필 이미지 + 세션 + 장르까지 다 넘겨줄 수가 없음 (맞나요)
![image](https://github.com/user-attachments/assets/f9615808-4c0a-4d17-9642-be4e6507ff16)
### 2. 모임에 지원했을 때 리뷰랑 같이 보여줌 (위 이미지에 탭바 추가)
-> 그러면 주최자 말고 다른 사람은 못봄
### 3. 특정 사용자가 올린 영상 리스트 보여주지말자

---

## 스크린샷
![image](https://github.com/user-attachments/assets/de74250b-01d7-4878-9070-b6f39b49792a)
